### PR TITLE
Update mpv.conf 优化条件组 `[Deband]` YUV420P10 以下的源开启去色带（排除8K视频）

### DIFF
--- a/mpv.conf
+++ b/mpv.conf
@@ -859,10 +859,10 @@ profile=NNEDI3                                # 适用于大多数场景（NNEDI
  profile=FSRCNNX+
 
 [Deband]
- profile-desc=YUV420P10 以下的源开启去色带
- profile-cond=get("video-params/average-bpp") < 24
- profile-restore=copy
- deband=yes
+profile-desc=YUV420P10 以下的源开启去色带
+profile-cond=get("video-params/average-bpp") < 24 and not (get("video-params/w") > 7000 or get("video-params/h") > 3000)
+profile-restore=copy
+deband=yes
 
 [hdr-2390]
  profile-cond=p.tone_mapping == "bt.2390" and p.current_vo == "gpu-next"

--- a/script-opts/uosc_danmaku.conf
+++ b/script-opts/uosc_danmaku.conf
@@ -1,14 +1,13 @@
 ## 指定弹幕服务器地址，自定义服务需兼容 dandanplay 的 api
+## 可指定多个用逗号分隔的有序 api_server 列表
 api_server=https://api.dandanplay.net
 ## 指定 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕
-## 服务器可以自托管：https://github.com/lyz05/danmaku
-#fallback_server=https://fc.lyz05.cn
+## 可用： https://api.danmu.icu，https://dmku.hls.one
+#fallback_server=https://api.danmu.icu
 ## 设置 tmdb 的 API Key，用于获取非动画条目的中文信息(当搜索内容非中文时)
 ## 可以在 https://www.themoviedb.org 注册后去个人账号设置界面获取
 ## 注意：自定义此参数时还需要对获取到的 API Key 进行 base64 编码
 #tmdb_api_key=NmJmYjIxOTZkNzIyN2UyMTIzMGM3Y2YzZjQ4MDNkZGM=
-## 加载更多来自弹幕服务器上第三方的弹幕
-load_more_danmaku=no
 ## 自动加载网络弹幕
 auto_load=no
 ## 自动加载本地弹幕

--- a/scripts/uosc_danmaku/README.md
+++ b/scripts/uosc_danmaku/README.md
@@ -7,7 +7,7 @@
 
 > [!NOTE]
 > 已添加对mpv内部 `mp.input`的支持，在uosc不可用时通过键绑定调用此方式渲染菜单
->
+> 
 > 欲启用此支持mpv最低版本要求：0.39.0
 
 ## 项目简介
@@ -24,25 +24,38 @@
 <details open>
 
 1. 从弹弹play或自定义服务的API获取剧集及弹幕数据，并根据用户选择的集数加载弹幕
-2. 通过点击uosc control bar中的弹幕搜索按钮可以显示搜索菜单供用户选择需要的弹幕
-3. 通过点击加入uosc control bar中的弹幕开关控件可以控制弹幕的开关
-4. 通过点击加入uosc control bar中的[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)按钮可以通过受支持的网络源或本地文件添加弹幕
-5. 通过点击加入uosc control bar中的[弹幕样式](#实时修改弹幕样式可选)按钮可以打开uosc弹幕样式菜单供用户在视频播放时实时修改弹幕样式（注意⚠️：未安装uosc框架时该功能不可用）
-6. 通过点击加入uosc control bar中的[弹幕设置](#弹幕设置总菜单可选)按钮可以打开多级功能复合菜单，包含了插件目前所有的图形化功能。
-7. 通过点击加入uosc control bar中的[弹幕源延迟设置](#弹幕源延迟设置可选)按钮可以打开弹幕源延迟控制菜单，可以独立控制每个弹幕源的延迟（注意⚠️：未安装uosc框架时该功能不可用）
-8. 记忆型全自动弹幕填装，在为某个文件夹下的某一集番剧加载过一次弹幕后，加载过的弹幕会自动关联到该集；之后每次重新播放该文件就会自动加载弹幕，同时该文件对应的文件夹下的所有其他集数的文件都会在播放时自动加载弹幕，无需再重复手动输入番剧名进行搜索（注意⚠️：全自动弹幕填装默认关闭，如需开启请阅读[auto_load配置项说明](#auto_load)）
-9. 在没有手动加载过弹幕，没有填装自动弹幕记忆之前，通过文件哈希匹配的方式自动添加弹幕（~仅限本地文件~，现已支持网络视频），对于能够哈希匹配关联的文件不再需要手动搜索关联，实现全自动加载弹幕并添加记忆。该功能随记忆型全自动弹幕填装功能一起开启（哈希匹配自动加载准确率较低，如关联到错误的剧集请手动加载正确的剧集）
 
+2. 通过点击uosc control bar中的弹幕搜索按钮可以显示搜索菜单供用户选择需要的弹幕
+
+3. 通过点击加入uosc control bar中的弹幕开关控件可以控制弹幕的开关
+
+4. 通过点击加入uosc control bar中的[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)按钮可以通过受支持的网络源或本地文件添加弹幕
+
+5. 通过点击加入uosc control bar中的[弹幕样式](#实时修改弹幕样式可选)按钮可以打开uosc弹幕样式菜单供用户在视频播放时实时修改弹幕样式（注意⚠️：未安装uosc框架时该功能不可用）
+
+6. 通过点击加入uosc control bar中的[弹幕设置](#弹幕设置总菜单可选)按钮可以打开多级功能复合菜单，包含了插件目前所有的图形化功能。
+
+7. 通过点击加入uosc control bar中的[弹幕源延迟设置](#弹幕源延迟设置可选)按钮可以打开弹幕源延迟控制菜单，可以独立控制每个弹幕源的延迟（注意⚠️：未安装uosc框架时该功能不可用）
+
+8. 记忆型全自动弹幕填装，在为某个文件夹下的某一集番剧加载过一次弹幕后，加载过的弹幕会自动关联到该集；之后每次重新播放该文件就会自动加载弹幕，同时该文件对应的文件夹下的所有其他集数的文件都会在播放时自动加载弹幕，无需再重复手动输入番剧名进行搜索（注意⚠️：全自动弹幕填装默认关闭，如需开启请阅读[auto_load配置项说明](#auto_load)）
+
+9. 在没有手动加载过弹幕，没有填装自动弹幕记忆之前，通过文件哈希匹配的方式自动添加弹幕（~仅限本地文件~，现已支持网络视频），对于能够哈希匹配关联的文件不再需要手动搜索关联，实现全自动加载弹幕并添加记忆。该功能随记忆型全自动弹幕填装功能一起开启（哈希匹配自动加载准确率较低，如关联到错误的剧集请手动加载正确的剧集）
+   
    > 哈希匹配功能需要 mpv 基于 LuaJIT 或 Lua 5.2 构建，不支持 Lua 5.1
-   >
-10. 通过打开配置项load_more_danmaku可以爬取所有可用弹幕源，获取更多弹幕（注意⚠️：爬取所有可用弹幕源默认关闭，如需开启请阅读[load_more_danmaku配置项说明](#load_more_danmaku)）
-11. 自动记忆弹幕开关情况，播放视频时保持上次关闭时的弹幕开关状态
-12. 自定义默认播放弹幕样式（具体设置方法详见[自定义弹幕样式](#自定义弹幕样式相关配置)）
-13. 在使用如[Play-With-MPV](https://github.com/LuckyPuppy514/Play-With-MPV)或[ff2mpv](https://github.com/woodruffw/ff2mpv)等网络播放手段时，自动加载弹幕（注意⚠️：目前支持自动加载bilibili和巴哈姆特这两个网站的弹幕，具体说明查看[autoload_for_url配置项说明](#autoload_for_url)）
-14. 保存当前弹幕到本地（详细功能说明见[save_danmaku配置项说明](#save_danmaku)）
-15. 可以合并一定时间段内同时出现的大量重复弹幕（具体设置方法详见[merge_tolerance配置项说明](#merge_tolerance)）
-16. 弹幕简体字繁体字转换，解决弹幕简繁混杂问题（具体设置方法详见[chConvert配置项说明](#chConvert)）
-17. 自定义插件相关提示的显示位置，可以自由调节距离画面左上角的两个维度的距离（具体设置方法详见[message_x配置项说明](#message_x)和[message_y配置项说明](#message_y)）
+
+10. 自动记忆弹幕开关情况，播放视频时保持上次关闭时的弹幕开关状态
+
+11. 自定义默认播放弹幕样式（具体设置方法详见[自定义弹幕样式](#自定义弹幕样式相关配置)）
+
+12. 在使用如[Play-With-MPV](https://github.com/LuckyPuppy514/Play-With-MPV)或[ff2mpv](https://github.com/woodruffw/ff2mpv)等网络播放手段时，自动加载弹幕（注意⚠️：目前支持自动加载bilibili和巴哈姆特这两个网站的弹幕，具体说明查看[autoload_for_url配置项说明](#autoload_for_url)）
+
+13. 保存当前弹幕到本地（详细功能说明见[save_danmaku配置项说明](#save_danmaku)）
+
+14. 可以合并一定时间段内同时出现的大量重复弹幕（具体设置方法详见[merge_tolerance配置项说明](#merge_tolerance)）
+
+15. 弹幕简体字繁体字转换，解决弹幕简繁混杂问题（具体设置方法详见[chConvert配置项说明](#chConvert)）
+
+16. 自定义插件相关提示的显示位置，可以自由调节距离画面左上角的两个维度的距离（具体设置方法详见[message_x配置项说明](#message_x)和[message_y配置项说明](#message_y)）
 
 无需亲自下载整合弹幕文件资源，无需亲自处理文件格式转换，在mpv播放器中一键加载包含了哔哩哔哩、巴哈姆特等弹幕网站弹幕的弹弹play的动画弹幕。
 
@@ -69,7 +82,7 @@
 想要使用本插件，请将本插件完整地[下载](https://github.com/Tony15246/uosc_danmaku/releases)或者克隆到 `scripts`目录下即可使用，文件结构参阅下方
 
 > [!IMPORTANT]
->
+> 
 > 1. scripts目录下放置本插件的文件夹名称必须为uosc_danmaku，否则必须参照uosc控件配置部分[修改uosc控件](#修改uosc控件可选)
 > 2. 记得给bin文件夹下的文件赋予可执行权限
 
@@ -236,12 +249,12 @@ key script-message open_source_delay_menu
 
 > #### 实时修改弹幕样式（可选）
 
-依赖于[uosc UI框架](https://github.com/tomasklaen/uosc)实现**弹幕样式实时修改**，将打开弹幕样式修改图形化菜单供用户手动修改，该功能目前仅依靠 uosc 实现（uosc不可用时无法使用此功能，并默认使用[自定义弹幕样式](#自定义弹幕样式相关配置)里的样式配置）。想要启用此功能，需要参照[uosc控件配置](#uosc控件配置)，根据uosc版本添加 `button:danmaku_styles`或 `command:palette:script-message open_setup_danmaku_menu?弹幕样式`到 `uosc.conf`的controls配置项中。
+依赖于[uosc UI框架](https://github.com/tomasklaen/uosc)实现**弹幕样式实时修改**，将打开弹幕样式修改图形化菜单供用户手动修改（默认使用[自定义弹幕样式](#自定义弹幕样式相关配置)里的样式配置）。想要启用此功能，需要参照[uosc控件配置](#uosc控件配置)，根据uosc版本添加 `button:danmaku_styles`或 `command:palette:script-message open_danmaku_style_menu?弹幕样式`到 `uosc.conf`的controls配置项中。
 
-想要通过快捷键使用此功能，请添加类似下面的配置到 `input.conf`中。实时修改弹幕样式功能对应的脚本消息为 `open_setup_danmaku_menu`。
+想要通过快捷键使用此功能，请添加类似下面的配置到 `input.conf`中。实时修改弹幕样式功能对应的脚本消息为 `open_danmaku_style_menu`。
 
 ```
-key script-message open_setup_danmaku_menu
+key script-message open_danmaku_style_menu
 ```
 
 </details>
@@ -337,76 +350,6 @@ key script-message check-update
 ### 弹幕加载相关
 
 <!--  下列是弹幕加载相关  -->
-
-<details>
-<summary>
-load_more_danmaku
-
-> 开关全量弹幕源加载
-
-</summary>
-
-### load_more_danmaku
-
-#### 功能说明
-
-由于弹弹Play默认对于弹幕较多的番剧加载并且整合弹幕的上限大约每集7000条，而这7000条弹幕也不是均匀分配，例如有时弹幕基本只来自于哔哩哔哩，有时弹幕又只来自于巴哈姆特。这样的话弹幕观看体验就和直接在哔哩哔哩或者巴哈姆特观看没有区别了，失去了弹弹Play整合全平台弹幕的优势。
-
-因此，本人添加了配置选项 `load_more_danmaku`，用来将从弹弹Play获取弹幕的逻辑更改为逐一搜索所有弹幕源下的全部弹幕，并由本脚本整合加载。开启此选项可以获取到所有可用弹幕源下的所有弹幕。但是对于一些热门番剧来说，弹幕数量可能破万，如果接受不了屏幕上弹幕太多，请不要开启此选项。（嘛，不过本人看视频从来只会觉得弹幕多多益善）
-
-#### 使用方法
-
-想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
-
-```
-load_more_danmaku=yes
-```
-
-</details>
-
----
-
-<details>
-<summary>
-excluded_platforms
-
-> 排除指定平台的弹幕源
-
-</summary>
-
-### excluded_platforms
-
-#### 功能说明
-
-排除指定平台的弹幕源，支持域名关键词匹配。多个平台用逗号分隔。
-
-当启用 `load_more_danmaku` 选项时，脚本会从弹弹play API 获取所有相关弹幕源。此选项允许你过滤掉不想要的平台弹幕。
-
-#### 常见平台
-
-- `bilibili.com` - B站
-- `gamer.com.tw` - 巴哈姆特
-- `acfun.cn` - A站
-- `iqiyi.com` - 爱奇艺
-- `qq.com` - 腾讯视频
-- `youku.com` - 优酷
-
-#### 使用示例
-
-想要开启此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并添加如下内容：
-
-```
-excluded_platforms=["bilibili.com", "gamer.com.tw", "iqiyi.com"]
-```
-
-注意⚠️：
-- 此选项仅在 `load_more_danmaku=yes` 时生效
-- 使用 JSON 数组格式，注意保留方括号和引号
-- 支持域名关键词匹配，不需要精确匹配完整URL
-
-</details>
-
----
 
 <details>
 <summary>
@@ -532,11 +475,11 @@ save_danmaku
 当文件关闭时自动保存弹幕文件（xml格式）至视频同目录，保存的弹幕文件名与对应的视频文件名相同。配合[autoload_local_danmaku选项](#autoload_local_danmaku)可以实现弹幕自动保存到本地并且下次播放时自动加载本地保存的弹幕。此功能默认禁用。
 
 > **⚠️NOTE！**
->
+> 
 > 当开启[autoload_local_danmaku选项](#autoload_local_danmaku)时，会自动加载播放文件同目录下同名的 xml 格式的弹幕文件，优先级高于一切其他自动加载弹幕功能。如果不希望每次播放都加载之前保存的本地弹幕，则请关闭[autoload_local_danmaku选项](#autoload_local_danmaku)；或者在保存完弹幕之后转移弹幕文件至其他路径并关闭 `save_danmaku`选项。
->
+> 
 > `save_danmaku`选项的打开和关闭可以运行时实时更新。在 `input.conf`中添加如下内容，可通过快捷键实时控制 `save_danmaku`选项的打开和关闭
->
+> 
 > ```
 > key cycle-values script-opts uosc_danmaku-save_danmaku=yes uosc_danmaku-save_danmaku=no
 > ```
@@ -565,7 +508,7 @@ save_danmaku=yes
 ### add_from_source
 
 > **⚠️NOTE！**
->
+> 
 > 该可选配置项在Release v1.2.0之后已废除。现在通过 `从弹幕源向当前弹幕添加新弹幕内容`功能关联过的弹幕源被记录，并且下次播放同一个视频的时候自动关联并加载所有添加过的弹幕源，这样的行为已经成为了插件的默认行为，不需要再通过 `add_from_source`来开启。在[从源获取弹幕](#从弹幕源向当前弹幕添加新弹幕内容可选)菜单中可以可视化地管理所有添加过的弹幕源。
 
 #### 功能说明
@@ -669,6 +612,7 @@ merge_tolerance=1
 </details>
 
 ---
+
 <details>
 <summary>
 max_screen_danmaku
@@ -769,10 +713,12 @@ api_server
 
 #### 功能说明
 
-允许自定义弹幕 API 的服务地址
+允许自定义弹幕 API 的服务地址，可指定多个用逗号分隔的有序 api_server 列表
+
+支持每项使用 '|' 或 '#' 分隔备注，例如: "https://a.example.com|备用A" 或 "https://b.example.com#备用B"
 
 > **⚠️NOTE！**
->
+> 
 > 请确保自定义服务的 API 与弹弹play 的兼容，已知兼容：[misaka_danmu_server](https://github.com/l429609201/misaka_danmu_server)，[danmu_api](https://github.com/huangxd-/danmu_api)
 
 #### 使用方法
@@ -799,18 +745,18 @@ fallback_server
 
 #### 功能说明
 
-自定义 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕，只有在弹弹play无法解析视频源对应弹幕的情况下才会使用此处设置的服务器进行解析。兜底弹幕服务器可以自托管，具体方法请参考此仓库：https://github.com/lyz05/danmaku
+自定义 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕，只有在弹弹play无法解析视频源对应弹幕的情况下才会使用此处设置的服务器进行解析。可用： https://api.danmu.icu，https://dmku.hls.one
 
 > **⚠️NOTE！**
->
-> 不设置此选项的情况下默认使用 `https://fc.lyz05.cn`作为兜底服务器，除非你自行部署了弹幕服务器，否则不建议自定义此选项。
+> 
+> 不设置此选项的情况下默认使用 ` https://api.danmu.icu`作为兜底服务器
 
 #### 使用方法
 
 想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容：
 
 ```
-fallback_server=https://fc.lyz05.cn
+fallback_server=https://api.danmu.icu
 ```
 
 </details>
@@ -832,7 +778,7 @@ tmdb_api_key
 设置 tmdb 的 API Key，用于获取非动画条目的中文信息(当搜索内容非中文时)。可以在 https://www.themoviedb.org 注册后去个人账号设置界面获取个人的tmdb 的 API Key。
 
 > **⚠️NOTE！**
->
+> 
 > 不设置此选项的情况下默认使用专为本项目申请的API Key。另外，自定义此选项时还需要对获取到的 API Key 进行 base64 编码。
 
 #### 使用方法
@@ -868,9 +814,9 @@ user_agent
 想要使用此选项，请在mpv配置文件夹下的 `script-opts`中创建 `uosc_danmaku.conf`文件并自定义如下内容（不可为空）：
 
 > **⚠️NOTE！**
->
+> 
 > User-Agent格式必须符合弹弹play的标准，否则无法成功请求。具体格式要求见[弹弹play官方文档](https://github.com/kaedei/dandanplay-libraryindex/blob/master/api/OpenPlatform.md#5user-agent)
->
+> 
 > 若想提高URL播放的哈希匹配成功率，可以将此项设为 `mpv`或浏览器的User-Agent
 
 ```
@@ -1061,15 +1007,14 @@ outline=1
 ##支持 lua 的正则表达式写法
 blacklist_path=
 ```
+
 ## 插件自定义属性
 
 - `user-data/uosc_danmaku/danmaku-delay`
 
-
     从 `user-data/uosc_danmaku/danmaku-delay`属性中可以获取到当前弹幕延迟的值，具体用法可以参考[此issue](https://github.com/Tony15246/uosc_danmaku/issues/77)
 
 - `user-data/uosc_danmaku/has-danmaku`
-
     从`user-data/uosc_danmaku/has-danmaku`属性中可以获取到表示当前是否有弹幕在显示的布尔值，具体用法可以参考[此pr](https://github.com/Tony15246/uosc_danmaku/pull/276)
 
 ## 常见问题

--- a/scripts/uosc_danmaku/apis/dandanplay.lua
+++ b/scripts/uosc_danmaku/apis/dandanplay.lua
@@ -21,9 +21,10 @@ end
 
 -- 写入history.json
 -- 读取episodeId获取danmaku
-function set_episode_id(input, from_menu)
+function set_episode_id(input, from_menu, api_server)
     from_menu = from_menu or false
     DANMAKU.source = "dandanplay"
+    local selected_server = api_server
     for url, source in pairs(DANMAKU.sources) do
         if source.from == "api_server" then
             if not source.from_history then
@@ -33,51 +34,43 @@ function set_episode_id(input, from_menu)
             end
         end
     end
-    local episodeId = tonumber(input)
-    write_history(episodeId)
-    set_danmaku_button()
-    if options.load_more_danmaku and options.api_server:find("api%.dandanplay%.") then
-        fetch_danmaku_all(episodeId, from_menu)
-    else
-        fetch_danmaku(episodeId, from_menu)
+
+    if not api_server then
+        if DANMAKU.api_server ~= nil then
+            selected_server = DANMAKU.api_server
+        else
+            local servers = get_api_server_list(options.api_server)
+            if servers and #servers > 0 then
+                selected_server = servers[1]
+            end
+        end
     end
+
+    DANMAKU.api_server = selected_server
+
+    local episodeId = tonumber(input)
+    write_history(episodeId, selected_server)
+    set_danmaku_button()
+    fetch_danmaku(episodeId, from_menu, selected_server)
 end
 
 -- 回退使用额外的弹幕获取方式
 function get_danmaku_fallback(query)
-    local url = options.fallback_server .. "/?url=" .. query
+    local url = options.fallback_server .. "/?ac=dm&url=" .. query
     msg.verbose("尝试获取弹幕：" .. url)
-    local temp_file = "danmaku-" .. PID .. DANMAKU.count .. ".xml"
-    local danmaku_xml = utils.join_path(DANMAKU_PATH, temp_file)
-    DANMAKU.count = DANMAKU.count + 1
-    local arg = {
-        "curl",
-        "-L",
-        "-s",
-        "--compressed",
-        "--user-agent",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0",
-        "--output",
-        danmaku_xml,
-        url,
-    }
 
-    if options.proxy ~= "" then
-        table.insert(arg, '-x')
-        table.insert(arg, options.proxy)
-    end
+    local args = make_danmaku_request_args("GET", url)
+    if not args then return end
 
-    call_cmd_async(arg, function(error)
-        async_running = false
-        if error then
-            show_message("HTTP 请求失败，打开控制台查看详情", 5)
-            msg.error(error)
+    fetch_danmaku_data(args, function(data)
+        if not data or not data["comments"] or data["count"] <= 1 then
+            msg.info("备用服务器无数据或返回格式不正确")
+            show_message("备用服务器无数据或返回格式不正确", 3)
             return
         end
-        if file_exists(danmaku_xml) then
-            save_danmaku_downloaded(query, danmaku_xml)
-            load_danmaku(true)
-        end
+
+        save_danmaku_data(data["comments"], query, "user_custom")
+        load_danmaku(true)
     end)
 end
 
@@ -130,9 +123,48 @@ function make_danmaku_request_args(method, url, headers, body)
     return args
 end
 
+local function normalize_danmaku_response(d)
+    if not d then return d end
+    -- 已经是 comments/count 格式则直接返回
+    if d.comments or d.count then return d end
+
+    if d.danmuku and type(d.danmuku) == "table" then
+        local out = {}
+        for _, item in ipairs(d.danmuku) do
+            -- item 预期为数组，索引: 1=time, 2=pos(right/top/bottom), 3=color(hex), 5=content
+            local time = tonumber(item[1]) or 0
+            local pos = item[2] or "right"
+            local color = item[3] or ""
+            local content = item[5] or item[4] or ""
+
+            local mode = 1
+            if pos == "right" then
+                mode = 1
+            elseif pos == "top" then
+                mode = 4
+            elseif pos == "bottom" then
+                mode = 5
+            end
+
+            local colorDec = 16777215
+            if type(color) == "number" then
+                colorDec = color
+            elseif type(color) == "string" then
+                colorDec = hex_to_int_color(color)
+            end
+
+            local p = string.format("%.2f,%d,%d", time, mode, colorDec)
+            table.insert(out, { p = p, m = content })
+        end
+        return { comments = out, count = tonumber(d.danum) or #out }
+    end
+
+    return d
+end
+
 -- 尝试通过解析文件名匹配剧集
-local function match_episode(animeTitle, bangumiId, episode_num)
-    local url = options.api_server .. "/api/v2/bangumi/" .. bangumiId
+local function match_episode(animeTitle, bangumiId, episode_num, api_server)
+    local url = api_server .. "/api/v2/bangumi/" .. bangumiId
     local args = make_danmaku_request_args("GET", url)
 
     if args == nil then
@@ -140,7 +172,6 @@ local function match_episode(animeTitle, bangumiId, episode_num)
     end
 
     call_cmd_async(args, function(error, json)
-        async_running = false
         if error then
             show_message("HTTP 请求失败，打开控制台查看详情", 5)
             msg.error(error)
@@ -158,7 +189,7 @@ local function match_episode(animeTitle, bangumiId, episode_num)
             if ep_num and ep_num == tonumber(episode_num) then
                 DANMAKU.anime = animeTitle
                 DANMAKU.episode = episode.episodeTitle
-                set_episode_id(episode.episodeId)
+                set_episode_id(episode.episodeId, nil, api_server)
                 break
             end
         end
@@ -166,9 +197,7 @@ local function match_episode(animeTitle, bangumiId, episode_num)
 end
 
 local function match_anime()
-    local animes = {}
     local anime_type = "tvseries"
-    local type_count = 0
     local title, season_num, episode_num = parse_title()
     if not episode_num then
         msg.info("无法解析剧集信息")
@@ -179,65 +208,81 @@ local function match_anime()
         anime_type = "ova"
     end
 
+    -- 并发在多个 api_server 上搜索，遇到第一个可接受的匹配就取消其余请求
     local encoded_query = url_encode(title)
-    local url = options.api_server .. "/api/v2/search/anime"
-    local params = "keyword=" .. encoded_query
-    local full_url = url .. "?" .. params
-    local args = make_danmaku_request_args("GET", full_url)
+    local servers = get_api_server_list(options.api_server)
 
-    if not args then return end
+    local matched = false
+    local cancel_fn = nil
 
-    call_cmd_async(args, function(error, json)
-        async_running = false
-        if error then
-            show_message("HTTP 请求失败，打开控制台查看详情", 5)
-            msg.error(error)
+    local function build_args(server)
+        local url = server .. "/api/v2/search/anime"
+        local full_url = url .. "?keyword=" .. encoded_query
+        return make_danmaku_request_args("GET", full_url)
+    end
+
+    local function per_response(server, err, out)
+        if matched then return end
+        if err then
+            msg.debug(("search anime failed for %s: %s"):format(server, tostring(err)))
             return
         end
-
-        local data = utils.parse_json(json)
+        local data = utils.parse_json(out)
         if not data or not data.animes then
-            msg.info("无结果")
             return
         end
-
+        local local_candidates = {}
         for _, anime in ipairs(data.animes) do
             if anime.type == anime_type then
-                type_count = type_count + 1
-                table.insert(animes, anime)
+                table.insert(local_candidates, anime)
             end
         end
-
-        if type_count == 1 then
-            match_episode(animes[1].animeTitle, animes[1].bangumiId, episode_num)
-        elseif type_count > 1 and season_num then
+        if #local_candidates == 1 then
+            matched = true
+            local a = local_candidates[1]
+            match_episode(a.animeTitle, a.bangumiId, episode_num, server)
+            if cancel_fn then pcall(cancel_fn) end
+            return
+        end
+        if #local_candidates > 1 and season_num then
             local best_match, best_score = nil, -1
             local target_title = title
             if tonumber(season_num) > 1 then
                 target_title = title .. " 第" .. number_to_chinese(season_num) .. "季"
             end
-            for _, anime in ipairs(animes) do
-                if anime.animeTitle:match("第一[季部]") and tonumber(season_num) == 1 then
+            for _, anime in ipairs(local_candidates) do
+                local animeTitle = tostring(anime.animeTitle or "")
+                animeTitle = animeTitle:gsub("^%s*(.-)%s*$", "%1")
+                            :gsub("%s*%(.-%)%s*$", "")
+                            :gsub("%s*【.-】.*$", "")
+                if animeTitle:match("第一[季部]") and tonumber(season_num) == 1 then
                     target_title = title .. " 第一季"
                 end
-                local score = jaro_winkler(target_title, anime.animeTitle)
-                msg.debug(("候选: %s -> 相似度 %.3f"):format(anime.animeTitle, score))
+                local score = jaro_winkler(target_title, animeTitle)
+                msg.debug(("候选: %s -> 相似度 %.3f"):format(animeTitle, score))
                 if score > best_score then
                     best_score = score
                     best_match = anime
                 end
             end
-
             if best_match and best_score >= 0.75 then
+                matched = true
                 msg.info(("模糊匹配选中: %s (score=%.2f)"):format(best_match.animeTitle, best_score))
-                match_episode(best_match.animeTitle, best_match.bangumiId, episode_num)
-            else
-                msg.info("匹配到多个结果，但相似度不足，请手动搜索")
+                match_episode(best_match.animeTitle, best_match.bangumiId, episode_num, server)
+                if cancel_fn then pcall(cancel_fn) end
+                return
             end
-        else
+        end
+        -- 未找到可接受匹配，继续等待其他服务器的返回
+    end
+
+    local function final_cb()
+        if not matched then
             msg.info("没有找到合适的匹配结果")
         end
-    end)
+    end
+
+    cancel_fn = parallel_requests(servers, build_args, per_response, final_cb, { concurrency = 5, per_request_timeout = 15 })
 end
 
 -- 执行哈希匹配获取弹幕
@@ -274,49 +319,58 @@ local function match_file(file_path, file_name, callback)
         file_name = title
     end
 
-    local url = options.api_server .. "/api/v2/match"
-    local args = make_danmaku_request_args("POST", url, {
-            ["Content-Type"] = "application/json"
-        }, {
+    local servers = get_api_server_list(options.api_server)
+
+    local matched = false
+    local cancel_fn = nil
+
+    local function build_args(server)
+        local url = server .. "/api/v2/match"
+        return make_danmaku_request_args("POST", url, { ["Content-Type"] = "application/json" }, {
             fileName = file_name,
             fileHash = hash or "a1b2c3d4e5f67890abcd1234ef567890",
             matchMode = "hashAndFileName"
-        }
-    )
+        })
+    end
 
-    if not args then return end
-
-    call_cmd_async(args, function(error, json)
-        async_running = false
-        if error then
-            show_message("HTTP 请求失败，打开控制台查看详情", 5)
-            callback(error)
+    local function per_response(server, err, out)
+        if matched then return end
+        if err then
+            msg.debug(("match failed for %s: %s"):format(server, tostring(err)))
             return
         end
-        local data = utils.parse_json(json)
-        if not data or not data.isMatched or #data.matches > 1 then
-            callback("没有匹配的剧集")
+        local data = utils.parse_json(out)
+        if not data or not data.isMatched then
             return
         end
-
+        matched = true
         DANMAKU.anime = data.matches[1].animeTitle
         DANMAKU.episode = data.matches[1].episodeTitle
 
-        -- 获取并加载弹幕数据
-        set_episode_id(data.matches[1].episodeId)
-    end)
+        set_episode_id(data.matches[1].episodeId, nil, server)
+        if cancel_fn then pcall(cancel_fn) end
+        if callback then pcall(callback) end
+    end
+
+    local function final_cb()
+        if not matched then
+            callback("没有匹配的剧集")
+        end
+    end
+
+    cancel_fn = parallel_requests(servers, build_args, per_response, final_cb, { concurrency = 5, per_request_timeout = 15 })
 end
 
 -- 异步获取弹幕数据
 function fetch_danmaku_data(args, callback)
     call_cmd_async(args, function(error, json)
-        async_running = false
         if error then
             show_message("获取数据失败", 3)
             msg.error("HTTP 请求失败：" .. error)
             return
         end
         local data = utils.parse_json(json)
+        data = normalize_danmaku_response(data)
         callback(data)
     end)
 end
@@ -344,118 +398,6 @@ function save_danmaku_downloaded(url, downloaded_file)
     end
 end
 
--- 处理弹幕数据
-function handle_danmaku_data(query, data, from_menu)
-    local comments = data["comments"]
-    local count = data["count"]
-
-    -- 如果没有数据，进行重试
-    if count == 0 then
-        show_message("服务器无缓存数据，再次尝试请求", 30)
-        msg.verbose("服务器无缓存数据，再次尝试请求")
-        -- 等待 2 秒后重试
-        local start = os.time()
-        while os.time() - start < 2 do
-            -- 空循环，等待 2 秒
-        end
-        -- 重新发起请求
-        local url = options.api_server .. "/api/v2/extcomment?url=" .. url_encode(query)
-        local args = make_danmaku_request_args("GET", url)
-
-        if args == nil then
-            return
-        end
-
-        fetch_danmaku_data(args, function(retry_data)
-            if not retry_data or not retry_data["comments"] or retry_data["count"] == 0 then
-                get_danmaku_fallback(query)
-                return
-            end
-            save_danmaku_data(retry_data["comments"], query, "user_custom")
-            load_danmaku(from_menu)
-        end)
-    else
-        save_danmaku_data(comments, query, "user_custom")
-        load_danmaku(from_menu)
-    end
-end
-
--- 处理第三方弹幕数据
-function handle_related_danmaku(index, relateds, related, shift, callback)
-    local url = options.api_server .. "/api/v2/extcomment?url=" .. url_encode(related["url"])
-    show_message(string.format("正在从第三方库装填弹幕 [%d/%d]", index, #relateds), 30)
-    msg.verbose("正在从第三方库装填弹幕：" .. url)
-
-    local args = make_danmaku_request_args("GET", url)
-
-    if args == nil then
-        return
-    end
-
-    fetch_danmaku_data(args, function(data)
-        local comments = {}
-        if data and data["comments"] then
-            if data["count"] == 0 then
-                -- 如果没有数据，稍等 2 秒重试
-                local start = os.time()
-                while os.time() - start < 2 do
-                    -- 空循环，等待 2 秒
-                end
-                fetch_danmaku_data(args, function(data)
-                    for _, comment in ipairs(data["comments"]) do
-                        comment["shift"] = shift
-                        table.insert(comments, comment)
-                    end
-                    callback(comments)
-                end)
-            else
-                for _, comment in ipairs(data["comments"]) do
-                    comment["shift"] = shift
-                    table.insert(comments, comment)
-                end
-                callback(comments)
-            end
-        else
-            show_message("无数据", 3)
-            msg.info("无数据")
-            callback(comments)
-        end
-    end)
-end
-
--- 处理dandan库的弹幕数据
-function handle_main_danmaku(url, from_menu)
-    show_message("正在从弹弹Play库装填弹幕", 30)
-    msg.verbose("尝试获取弹幕：" .. url)
-    local args = make_danmaku_request_args("GET", url)
-
-    if args == nil then
-        return
-    end
-
-    fetch_danmaku_data(args, function(data)
-        if not data or not data["comments"] then
-            show_message("无数据", 3)
-            msg.info("无数据")
-            return
-        end
-
-        local comments = data["comments"]
-        local count = data["count"]
-
-        if count == 0 then
-            if DANMAKU.sources[url] == nil then
-                DANMAKU.sources[url] = {from = "api_server"}
-            end
-            load_danmaku(from_menu)
-            return
-        end
-
-        save_danmaku_data(comments, url, "api_server")
-        load_danmaku(from_menu)
-    end)
-end
-
 -- 处理获取到的数据
 function handle_fetched_danmaku(data, url, from_menu)
     if data and data["comments"] then
@@ -475,51 +417,10 @@ function handle_fetched_danmaku(data, url, from_menu)
     end
 end
 
--- 过滤被排除的平台
-function filter_excluded_platforms(relateds)
-    -- 解析排除的平台列表
-    local excluded_list = {}
-    local excluded_json = options.excluded_platforms
-    if excluded_json and excluded_json ~= "" and excluded_json ~= "[]" then
-        local success, parsed = pcall(utils.parse_json, excluded_json)
-        if success and parsed and type(parsed) == "table" then
-            excluded_list = parsed
-        end
-    end
-
-    -- 如果没有排除列表，直接返回原列表
-    if #excluded_list == 0 then
-        return relateds
-    end
-
-    -- 过滤弹幕源
-    local filtered = {}
-    for _, related in ipairs(relateds) do
-        local url = related["url"]
-        local should_exclude = false
-
-        -- 检查URL是否包含任何被排除的平台关键词
-        for _, platform in ipairs(excluded_list) do
-            if url:find(platform, 1, true) then
-                should_exclude = true
-                msg.info(string.format("已排除平台 [%s] 的弹幕源: %s", platform, url))
-                break
-            end
-        end
-
-        if not should_exclude then
-            table.insert(filtered, related)
-        end
-    end
-
-    msg.info(string.format("原始弹幕源: %d 个, 过滤后: %d 个", #relateds, #filtered))
-    return filtered
-end
-
 -- 匹配弹幕库 comment, 仅匹配dandan本身弹幕库
 -- 通过danmaku api（url）+id获取弹幕
-function fetch_danmaku(episodeId, from_menu)
-    local url = options.api_server .. "/api/v2/comment/" .. episodeId .. "?withRelated=true&chConvert=0"
+function fetch_danmaku(episodeId, from_menu, api_server)
+    local url = api_server .. "/api/v2/comment/" .. episodeId .. "?withRelated=true&chConvert=0"
     show_message("弹幕加载中...", 30)
     msg.verbose("尝试获取弹幕：" .. url)
     local args = make_danmaku_request_args("GET", url)
@@ -530,58 +431,6 @@ function fetch_danmaku(episodeId, from_menu)
 
     fetch_danmaku_data(args, function(data)
         handle_fetched_danmaku(data, url, from_menu)
-    end)
-end
-
--- 主函数：获取所有相关弹幕
-function fetch_danmaku_all(episodeId, from_menu)
-    local url = options.api_server .. "/api/v2/related/" .. episodeId
-    show_message("弹幕加载中...", 30)
-    msg.verbose("尝试获取弹幕：" .. url)
-    local args = make_danmaku_request_args("GET", url)
-
-    if args == nil then
-        return
-    end
-
-    fetch_danmaku_data(args, function(data)
-        if not data or not data["relateds"] then
-            show_message("无数据", 3)
-            msg.info("无数据")
-            return
-        end
-
-        -- 处理所有的相关弹幕，过滤掉被排除的平台
-        local relateds = data["relateds"]
-        local filtered_relateds = filter_excluded_platforms(relateds)
-        local function process_related(index)
-            if index > #filtered_relateds then
-                -- 所有相关弹幕加载完成后，开始加载主库弹幕
-                url = options.api_server .. "/api/v2/comment/" .. episodeId .. "?withRelated=false&chConvert=0"
-                handle_main_danmaku(url, from_menu)
-                return
-            end
-
-            local related = filtered_relateds[index]
-            local shift = related["shift"]
-
-            -- 处理当前的相关弹幕
-            handle_related_danmaku(index, filtered_relateds, related, shift, function(comments)
-                if #comments == 0 then
-                    if DANMAKU.sources[related["url"]] == nil then
-                        DANMAKU.sources[related["url"]] = {from = "api_server"}
-                    end
-                else
-                    save_danmaku_data(comments, related["url"], "api_server")
-                end
-
-                -- 继续处理下一个相关弹幕
-                process_related(index + 1)
-            end)
-        end
-
-        -- 从第一个相关库开始请求
-        process_related(1)
     end)
 end
 
@@ -644,23 +493,60 @@ end
 --通过输入源url获取弹幕库
 function add_danmaku_source_online(query, from_menu)
     set_danmaku_button()
-    local url = options.api_server .. "/api/v2/extcomment?url=" .. url_encode(query)
     show_message("弹幕加载中...", 30)
-    msg.verbose("尝试获取弹幕：" .. url)
-    local args = make_danmaku_request_args("GET", url)
+    msg.verbose("尝试获取弹幕：" .. query)
 
-    if args == nil then
+    local servers = get_api_server_list(options.api_server)
+
+    -- 过滤掉指向 dandanplay.net 的服务器
+    local filtered = {}
+    for _, s in ipairs(servers) do
+        if type(s) == "string" and not s:lower():find("dandanplay%.net") then
+            table.insert(filtered, s)
+        end
+    end
+    servers = filtered
+    if #servers == 0 then
+        get_danmaku_fallback(query)
         return
     end
 
-    fetch_danmaku_data(args, function(data)
-        if not data or not data["comments"] then
-            show_message("此源弹幕无法加载", 3)
-            msg.verbose("此源弹幕无法加载")
+    local matched = false
+    local cancel_fn = nil
+
+    local function build_args(server)
+        local url = server .. "/api/v2/extcomment?url=" .. url_encode(query)
+        return make_danmaku_request_args("GET", url)
+    end
+
+    local function per_response(server, err, out)
+        if matched then return end
+        if err then
+            msg.debug(("extcomment failed for %s: %s"):format(server, tostring(err)))
             return
         end
-        handle_danmaku_data(query, data, from_menu)
-    end)
+        local data = utils.parse_json(out)
+        data = normalize_danmaku_response(data)
+        if not data or not data["comments"] or data["count"] <= 1 then
+            return
+        end
+        matched = true
+        -- 保存并加载弹幕
+        save_danmaku_data(data["comments"], query, "user_custom")
+        load_danmaku(from_menu)
+        -- 取消其他未完成请求
+        if cancel_fn then pcall(cancel_fn) end
+    end
+
+    local function final_cb()
+        if not matched then
+            -- 所有服务器都未返回有效弹幕，回退到备用服务器
+            msg.info("所有服务器均无有效弹幕，尝试备用服务器")
+            get_danmaku_fallback(query)
+        end
+    end
+
+    cancel_fn = parallel_requests(servers, build_args, per_response, final_cb, { concurrency = 3, per_request_timeout = 30 })
 end
 
 -- 将弹幕转换为 Lua table
@@ -728,8 +614,6 @@ function get_danmaku_with_hash(file_name, file_path)
         end
 
         call_cmd_async(arg, function(error)
-            async_running = false
-
             file_path = utils.join_path(DANMAKU_PATH, temp_file)
 
             match_file(file_path, file_name, function(error)

--- a/scripts/uosc_danmaku/apis/extra.lua
+++ b/scripts/uosc_danmaku/apis/extra.lua
@@ -12,9 +12,18 @@ local function load_extra_danmaku(url, episode, number, class, id, site, title, 
     local play_url = nil
     if url:match("^.-%.html") then
         play_url = url:match("^(.-%.html).*")
+    elseif url:match("^https?://v%.youku%.com/") and url:match("[?&]vid=") then
+        -- 转换 youku 的短链接形式 video?vid=... 到真实播放页 v_show/id_*.html
+        local vid = url:match("[?&]vid=([^&]+)")
+        if vid then
+            play_url = "https://v.youku.com/v_show/id_" .. vid .. ".html"
+        else
+            play_url = url:gsub("%?bsource=360ogvys$",""):gsub("&.*$","")
+        end
     else
-        play_url = url:gsub("%?bsource=360ogvys$","")
+        play_url = url:gsub("%?bsource=360ogvys$",""):gsub("&.*$","")
     end
+
     ENABLED = true
     DANMAKU.anime = title .. " (" .. year .. ")"
     DANMAKU.episode = "第" .. episode .. "话"
@@ -98,6 +107,63 @@ local function get_number(cat, id, site)
     return nil
 end
 
+local function get_episodes_v2(cat, id, site)
+    local s_param = string.format('[{"cat_id":"%s","ent_id":"%s","site":"%s"}]', tostring(cat), tostring(id), tostring(site))
+
+    local url = string.format("https://api.so.360kan.com/episodesv2?v_ap=1&s=%s", url_encode(s_param))
+
+    local cmd = { "curl", "-s", url }
+    local res = mp.command_native({
+        name = "subprocess",
+        args = cmd,
+        capture_stdout = true,
+        capture_stderr = true,
+    })
+
+    if not res.status or res.status ~= 0 then
+        msg.error("Failed to fetch episodesv2: " .. (res.stderr or "unknown error"))
+        return nil
+    end
+
+    local data_text = res.stdout or ""
+    -- 兼容 JSONP 和 纯 JSON：提取最外层括号内 JSON
+    local json_payload = data_text
+    local first_paren = data_text:find('%(')
+    local last_paren = data_text:match('.*()%)')
+    if first_paren and last_paren and last_paren > first_paren then
+        json_payload = data_text:sub(first_paren + 1, last_paren - 1)
+    end
+
+    local parsed = utils.parse_json(json_payload)
+    if not parsed then
+        msg.error("episodesv2: 解析返回失败: " .. (res.stdout or ""))
+        return nil
+    end
+
+    local episodes = {}
+    if parsed.code == 0 and parsed.data and #parsed.data > 0 then
+        local seriesHTML = parsed.data[1] and parsed.data[1].seriesHTML
+        if seriesHTML and seriesHTML.seriesPlaylinks then
+            for i, ep in ipairs(seriesHTML.seriesPlaylinks) do
+                local episode_url = nil
+                if type(ep) == 'string' then
+                    episode_url = ep
+                elseif type(ep) == 'table' and ep.url then
+                    episode_url = ep.url
+                end
+                if episode_url and episode_url ~= '' then
+                    table.insert(episodes, { index = i, url = episode_url })
+                end
+            end
+        end
+    end
+
+    if #episodes == 0 then
+        return nil
+    end
+    return episodes
+end
+
 function get_details(class, id, site, title, year, number, episodenum)
     local message = episodenum and "查询弹幕中..." or "加载数据中..."
     local menu_type = "menu_details"
@@ -120,58 +186,72 @@ function get_details(class, id, site, title, year, number, episodenum)
         cat = 4
     end
 
-    if not number and cat ~= 0 then
-        number = get_number(cat, id, site)
-    end
-    if not number or cat == 0 then
-        local message = "无结果"
-        if uosc_available and not episodenum then
-            update_menu_uosc(menu_type, menu_title, message, footnote)
-        else
-            show_message(message, 3)
-        end
-        msg.verbose("无结果")
-        return
-    end
-
-    local url = string.format("https://api.web.360kan.com/v1/detail?cat=%s&id=%s&start=1&end=%s&site=%s",
-        cat, id, number, site)
-
-    local cmd = { "curl", "-s", url }
-    local res = mp.command_native({
-        name = "subprocess",
-        args = cmd,
-        capture_stdout = true,
-        capture_stderr = true,
-    })
-
-    if not res.status or res.status ~= 0 then
-        local message = "无结果"
-        if uosc_available and not episodenum then
-            update_menu_uosc(menu_type, menu_title, message, footnote)
-        else
-            show_message(message, 3)
-        end
-        msg.verbose("无结果")
-        return
-    end
-
-    local result = utils.parse_json(res.stdout)
     local items = {}
-    if result and result.data and result.data.allepidetail then
-        local data = result.data.allepidetail
-        local playurl, episode = nil, nil
-        if episodenum then
-            for _, item in ipairs(data[site]) do
-                if tonumber(item.playlink_num) == tonumber(episodenum) then
-                    playurl = item.url
-                    episode = item.playlink_num
-                    break
-                end
+    local episodes = nil
+    if cat == 2 or cat == 4 then
+        episodes = get_episodes_v2(cat, id, site)
+    end
+
+    -- 统一构建 episode_rows：优先使用 episodesv2 返回的数据，否则使用 v1/detail
+    local episode_rows = nil
+    if episodes then
+        episode_rows = {}
+        for _, ep in ipairs(episodes) do
+            table.insert(episode_rows, { index = tostring(ep.index), url = ep.url })
+        end
+    else
+        if not number and cat ~= 0 then
+            number = get_number(cat, id, site)
+        end
+        if not number or cat == 0 then
+            local message = "无结果"
+            if uosc_available and not episodenum then
+                update_menu_uosc(menu_type, menu_title, message, footnote)
+            else
+                show_message(message, 3)
             end
-            if playurl then
-                load_extra_danmaku(playurl, episode, number, class, id, site, title, year)
-                return
+            msg.verbose("无结果")
+            return
+        end
+
+        local url = string.format("https://api.web.360kan.com/v1/detail?cat=%s&id=%s&start=1&end=%s&site=%s",
+            cat, id, number, site)
+
+        local cmd = { "curl", "-s", url }
+        local res = mp.command_native({
+            name = "subprocess",
+            args = cmd,
+            capture_stdout = true,
+            capture_stderr = true,
+        })
+
+        if not res.status or res.status ~= 0 then
+            local message = "无结果"
+            if uosc_available and not episodenum then
+                update_menu_uosc(menu_type, menu_title, message, footnote)
+            else
+                show_message(message, 3)
+            end
+            msg.verbose("无结果")
+            return
+        end
+
+        local result = utils.parse_json(res.stdout)
+        if result and result.data and result.data.allepidetail and result.data.allepidetail[site] then
+            episode_rows = {}
+            for _, it in ipairs(result.data.allepidetail[site]) do
+                table.insert(episode_rows, { index = tostring(it.playlink_num), url = it.url })
+            end
+        end
+    end
+
+    if episode_rows and #episode_rows > 0 then
+        if episodenum then
+            for _, ep in ipairs(episode_rows) do
+                if tonumber(ep.index) == tonumber(episodenum) then
+                    load_extra_danmaku(ep.url, ep.index, number, class, id, site, title, year)
+                    return
+                end
             end
         end
 
@@ -182,15 +262,15 @@ function get_details(class, id, site, title, year, number, episodenum)
             selectable = true,
         })
 
-        for _, item in ipairs(data[site]) do
+        for _, ep in ipairs(episode_rows) do
             table.insert(items, {
-                title = "第" .. item.playlink_num .. "集",
-                hint = item.playlink_num,
+                title = "第" .. ep.index .. "集",
+                hint = ep.index,
                 value = {
                     "script-message-to",
                     mp.get_script_name(),
                     "add-extra-event",
-                    item.url, item.playlink_num, number, class, id, site, title, year
+                    ep.url, ep.index, tostring(number), class, id, site, title, year
                 },
             })
         end

--- a/scripts/uosc_danmaku/main.lua
+++ b/scripts/uosc_danmaku/main.lua
@@ -1,4 +1,4 @@
-VERSION = "2.0.0"
+VERSION = "2.2.0"
 
 mp.commandv('script-message', 'uosc_danmaku-version', VERSION)
 
@@ -25,7 +25,6 @@ DANMAKU_PATH = os.getenv("TEMP") or "/tmp/"
 HISTORY_PATH = mp.command_native({"expand-path", options.history_path})
 PID = utils.getpid()
 DANMAKU = {sources = {}, count = 1}
-DELAYS = {}
 ENABLED, COMMENTS, DELAY = false, nil, 0
 DELAY_PROPERTY = string.format("user-data/%s/danmaku-delay", mp.get_script_name())
 mp.set_property_native(DELAY_PROPERTY, 0)
@@ -58,6 +57,8 @@ PLATFORM = (function()
     end
     return "linux"
 end)()
+
+local rebuild_convert_timer = nil
 
 function get_danmaku_visibility()
     local history_json = read_file(HISTORY_PATH)
@@ -141,21 +142,6 @@ local function extract_between_colons(input_string)
     end
 end
 
-local function hex_to_int_color(hex_color)
-    -- 移除颜色代码中的'#'字符
-    hex_color = hex_color:sub(2)  -- 只保留颜色代码部分
-
-    -- 提取R, G, B的十六进制值并转为整数
-    local r = tonumber(hex_color:sub(1, 2), 16)
-    local g = tonumber(hex_color:sub(3, 4), 16)
-    local b = tonumber(hex_color:sub(5, 6), 16)
-
-    -- 计算32位整数值
-    local color_int = (r * 256 * 256) + (g * 256) + b
-
-    return color_int
-end
-
 local function get_type_from_position(position)
     if position == 0 then
         return 1
@@ -171,11 +157,13 @@ end
 function get_delay_for_time(delay_segments, time)
     if not delay_segments or #delay_segments == 0 then return 0 end
 
-    table.sort(delay_segments, function(a, b) return a.start < b.start end)
+    local segs = {}
+    for i = 1, #delay_segments do segs[i] = delay_segments[i] end
+    table.sort(segs, function(a, b) return a.start < b.start end)
 
     local applied_delay = 0
-    for i = 1, #delay_segments do
-        local seg = delay_segments[i]
+    for i = 1, #segs do
+        local seg = segs[i]
         local delay = tonumber(seg.delay)
         if time >= seg.start and delay then
             applied_delay = applied_delay + delay
@@ -245,9 +233,29 @@ local function merge_delay_segments(segments)
     return merged
 end
 
-local function set_danmaku_delay(dly, time)
-    for url, source in pairs(DANMAKU.sources) do
-        if source.data and not source.blocked then
+function parse_delay_input(text)
+    if not text then return nil end
+    local s = tostring(text):gsub("%s+", "")
+    if s == "" then return nil end
+    -- XmYs 格式，允许负号在分钟部分
+    local m, sec = string.match(s, "^(%-?%d+)m(%d+)s$")
+    if m and sec then
+        m = tonumber(m)
+        sec = tonumber(sec)
+        if not m or not sec then return nil end
+        if m < 0 then sec = -sec end
+        return m * 60 + sec
+    end
+    -- 普通数字（整数或小数），支持负数
+    local n = tonumber(s)
+    if n ~= nil then return n end
+    return nil
+end
+
+local function set_danmaku_delay(dly, time, specific_source)
+    if specific_source then
+        local source = DANMAKU.sources[specific_source]
+        if source and source.data and not source.blocked then
             source.delay_segments = source.delay_segments or {}
             if dly == 0 then
                 source.delay_segments = {}
@@ -256,31 +264,51 @@ local function set_danmaku_delay(dly, time)
             else
                 table.insert(source.delay_segments, {start = 0, delay = dly})
             end
-
             source.delay = nil
-            table.sort(source.delay_segments, function(a, b) return a.start < b.start end)
-            add_source_to_history(url, source)
+            source.delay_segments = merge_delay_segments(source.delay_segments)
+            add_source_to_history(specific_source, source)
         end
-    end
-
-    if time then
-        table.insert(DELAYS, {start = time, delay = dly})
     else
-        table.insert(DELAYS, {start = 0, delay = dly})
+        for url, source in pairs(DANMAKU.sources) do
+            if source.data and not source.blocked then
+                source.delay_segments = source.delay_segments or {}
+                if dly == 0 then
+                    source.delay_segments = {}
+                elseif time then
+                    table.insert(source.delay_segments, {start = time, delay = dly})
+                else
+                    table.insert(source.delay_segments, {start = 0, delay = dly})
+                end
+
+                source.delay = nil
+                source.delay_segments = merge_delay_segments(source.delay_segments)
+                add_source_to_history(url, source)
+            end
+        end
     end
 
     if dly == 0 then
         DELAY = 0
-        DELAYS = {}
     else
         DELAY = DELAY + dly
     end
 
-    DELAYS = merge_delay_segments(DELAYS)
-
     if ENABLED and COMMENTS ~= nil then
         render()
     end
+
+    -- 防抖：批量重建 ASS 事件并渲染，避免频繁变更导致重复重建
+    if rebuild_convert_timer then
+        rebuild_convert_timer:kill()
+        rebuild_convert_timer = nil
+    end
+    rebuild_convert_timer = mp.add_timeout(0.1, function()
+        if convert_danmaku_to_ass_events then
+            convert_danmaku_to_ass_events(true)
+        end
+        render()
+        rebuild_convert_timer = nil
+    end)
 
     show_message('设置弹幕延迟: ' .. string.format("%.1f", DELAY + 1e-10) .. ' s')
     mp.set_property_native(DELAY_PROPERTY, DELAY)
@@ -310,7 +338,7 @@ local function clear_source()
     msg.verbose("已重置当前视频所有弹幕源更改")
 end
 
-function write_history(episodeid)
+function write_history(episodeid, api_server)
     local history = {}
     local path = mp.get_property("path")
     local dir = get_parent_directory(path)
@@ -350,6 +378,9 @@ function write_history(episodeid)
             history[dir].episodeId = episodeid
         elseif DANMAKU.extra then
             history[dir].extra = DANMAKU.extra
+        end
+        if api_server then
+            history[dir].api_server = api_server
         end
         write_json_file(HISTORY_PATH, history)
     end
@@ -424,6 +455,7 @@ function read_danmaku_source_record(path)
 
     local history = utils.parse_json(history_json) or {}
     local record = history[path]
+
     if not record or not record.sources then return end
 
     local sources = record.sources
@@ -482,6 +514,7 @@ function read_danmaku_source_record(path)
                 blocked = blocked,
                 delay_segments = delay_segments,
                 from_history = true,
+                api_server = record.api_server,
             }
 
             upgraded_sources[source] = shallow_copy(DANMAKU.sources[source])
@@ -576,8 +609,12 @@ function load_danmaku_for_bilibili(path)
             url,
         }
 
+        if options.cookie_file and options.cookie_file ~= "" then
+            table.insert(arg, '-b')
+            table.insert(arg, mp.command_native({"expand-path", options.cookie_file}))
+        end
+
         call_cmd_async(arg, function(error)
-            async_running = false
             if error then
                 show_message("HTTP 请求失败，打开控制台查看详情", 5)
                 msg.error(error)
@@ -629,8 +666,12 @@ function load_danmaku_for_bahamut(path)
         table.insert(arg, options.proxy)
     end
 
+    if options.cookie_file and options.cookie_file ~= "" then
+        table.insert(arg, '-b')
+        table.insert(arg, mp.command_native({"expand-path", options.cookie_file}))
+    end
+
     call_cmd_async(arg, function(error)
-        async_running = false
         if error then
             show_message("HTTP 请求失败，打开控制台查看详情", 5)
             msg.error(error)
@@ -644,30 +685,33 @@ function load_danmaku_for_bahamut(path)
         end
 
         local comments_json = read_file(danmaku_json)
+        os.remove(danmaku_json)
         local comments = utils.parse_json(comments_json)
         if not comments then
             return
         end
 
+        local output_table = {}
+        for _, comment in ipairs(comments) do
+            local color = hex_to_int_color(comment["color"])
+            local mode = get_type_from_position(comment["position"])
+            local time = tonumber(comment["time"]) / 10
+            local c_param = string.format("%s,%s,%s,25,,,", time, color, mode)
+            table.insert(output_table, {
+                c = c_param,
+                m = comment["text"]
+            })
+        end
+
+        local final_json_str = utils.format_json(output_table)
+
         temp_file = "danmaku-" .. PID .. DANMAKU.count .. ".json"
         local json_filename = utils.join_path(DANMAKU_PATH, temp_file)
         DANMAKU.count = DANMAKU.count + 1
+
         local json_file = io.open(json_filename, "w")
-
         if json_file then
-            json_file:write("[\n")
-            for _, comment in ipairs(comments) do
-                local m = comment["text"]
-                local color = hex_to_int_color(comment["color"])
-                local mode = get_type_from_position(comment["position"])
-                local time = tonumber(comment["time"]) / 10
-                local c = time .. "," .. color .. "," .. mode .. ",25,,,"
-
-                -- Write the JSON object as a single line, no spaces or extra formatting
-                local json_entry = string.format('{"c":"%s","m":"%s"},\n', c, m)
-                json_file:write(json_entry)
-            end
-            json_file:write("]")
+            json_file:write(final_json_str)
             json_file:close()
         end
 
@@ -725,6 +769,7 @@ function auto_load_danmaku(path, dir, filename, number)
                 local history_id = history_dir.episodeId
                 local history_fname = history_dir.fname
                 local history_extra = history_dir.extra
+                local history_api_server = history_dir.api_server
                 local playing_number = nil
 
                 if history_fname then
@@ -743,6 +788,7 @@ function auto_load_danmaku(path, dir, filename, number)
                 if playing_number ~= nil then
                     local x = playing_number - history_number --获取集数差值
                     DANMAKU.episode = episode_number and string.format("第%s话", episode_number + x) or history_dir.episodeTitle
+                    DANMAKU.api_server = history_api_server or nil
                     show_message("自动加载上次匹配的弹幕", 3)
                     msg.verbose("自动加载上次匹配的弹幕")
                     if history_id then
@@ -830,7 +876,7 @@ mp.register_event("file-loaded", function()
         return
     end
 
-    if ENABLED and COMMENTS == nil and not async_running then
+    if ENABLED and COMMENTS == nil and not is_async_running() then
         init(path)
     end
 end)
@@ -846,13 +892,18 @@ end)
 mp.register_script_message("danmaku-delay", function(...)
     local commands = {...}
     local delay_str, time_str = commands[1], commands[2]
-    local dly = tonumber(delay_str)
+    local source_arg = commands[3]
+    local dly = parse_delay_input(delay_str)
     local time = time_str and tonumber(time_str)
     if type(dly) ~= "number" then
         show_message("参数错误：缺少有效的延迟秒数", 3)
         return
     end
-    set_danmaku_delay(dly, time)
+    if source_arg and source_arg ~= "nil" then
+        set_danmaku_delay(dly, time, source_arg)
+    else
+        set_danmaku_delay(dly, time)
+    end
 end)
 
 mp.register_script_message("show_danmaku_keyboard", function()

--- a/scripts/uosc_danmaku/modules/menu.lua
+++ b/scripts/uosc_danmaku/modules/menu.lua
@@ -5,14 +5,182 @@ local unpack = unpack or table.unpack
 input_loaded, input = pcall(require, "mp.input")
 uosc_available = false
 latest_menu_anime = {}
+local active_request_cancel = nil
+local active_request_type = nil
+local request_cancelled = false
+
+-- 如果 latest_menu_anime 中存在首项为加载占位，移除它（兼容完整 menu props 或 items 数组）
+local function strip_loading_from_latest_menu_anime()
+    if not latest_menu_anime or #latest_menu_anime == 0 then return end
+    local parsed = utils.parse_json(latest_menu_anime)
+    if not parsed or type(parsed) ~= "table" then return end
+    local function is_loading_item(it)
+        if not it or type(it) ~= "table" then return false end
+        if it.title == "加载数据中..." then return true end
+        if it.italic == true and it.icon == "spinner" then return true end
+        return false
+    end
+    if parsed.items and type(parsed.items) == "table" then
+        if #parsed.items > 0 and is_loading_item(parsed.items[1]) then
+            table.remove(parsed.items, 1)
+            latest_menu_anime = utils.format_json(parsed)
+        end
+    else
+        if #parsed > 0 and is_loading_item(parsed[1]) then
+            table.remove(parsed, 1)
+            latest_menu_anime = utils.format_json(parsed)
+        end
+    end
+end
+
+-- 统一取消并发请求：设置取消标志、剥离加载占位并调用实际取消函数
+local function perform_cancel_active_request(expected_type)
+    if expected_type and active_request_type and tostring(expected_type) ~= tostring(active_request_type) then
+        return
+    end
+    if active_request_cancel then
+        request_cancelled = true
+        strip_loading_from_latest_menu_anime()
+        pcall(active_request_cancel)
+        active_request_cancel = nil
+        active_request_type = nil
+    end
+end
+
+local function make_build_args(encoded_query)
+    return function(server)
+        local url = server .. "/api/v2/search/anime"
+        local full_url = url .. "?keyword=" .. encoded_query
+        return make_danmaku_request_args("GET", full_url)
+    end
+end
+
+local function make_handle_response(ctx)
+    return function(server, err, out)
+        if request_cancelled then
+            ctx.remaining.n = math.max(0, ctx.remaining.n - 1)
+            return
+        end
+
+        local function do_final_update()
+            local final_items = {}
+            -- 按配置的 server 顺序拼接每个 server 的结果
+            for _, srv in ipairs(ctx.server_order or {}) do
+                local list = ctx.server_items and ctx.server_items[srv]
+                if list and type(list) == 'table' then
+                    for _, v in ipairs(list) do table.insert(final_items, v) end
+                end
+            end
+            if request_cancelled then return end
+            if uosc_available then
+                latest_menu_anime = update_menu_uosc(ctx.menu_type, ctx.menu_title, final_items, ctx.footnote, ctx.menu_cmd, ctx.query)
+            else
+                latest_menu_anime = utils.format_json(final_items)
+                if input_loaded then
+                    input.terminate()
+                    mp.add_timeout(0.1, function()
+                        open_menu_select(final_items)
+                    end)
+                end
+            end
+        end
+
+        if err then
+            msg.debug(("search anime failed for %s: %s"):format(server, tostring(err)))
+            ctx.remaining.n = math.max(0, ctx.remaining.n - 1)
+            if ctx.remaining.n == 0 then pcall(do_final_update) end
+            return
+        end
+        local data = utils.parse_json(out)
+        if not data or not data.animes then
+            ctx.remaining.n = math.max(0, ctx.remaining.n - 1)
+            if ctx.remaining.n == 0 then pcall(do_final_update) end
+            return
+        end
+        for _, anime in ipairs(data.animes) do
+            local key = anime.bangumiId or (anime.animeTitle and anime.animeTitle:gsub("%s+", " ") or nil)
+            if key and not ctx.seen[key] then
+                ctx.seen[key] = true
+                ctx.server_items[server] = ctx.server_items[server] or {}
+                local note = (ctx.server_notes and ctx.server_notes[server]) or nil
+                local hint = anime.typeDescription
+                if note and note ~= "" then
+                    if hint and hint ~= "" then
+                        hint = hint .. "|" .. note
+                    else
+                        hint = note
+                    end
+                end
+                table.insert(ctx.server_items[server], {
+                    title = anime.animeTitle,
+                    hint = hint,
+                    value = { "script-message-to", mp.get_script_name(), "search-episodes-event", anime.animeTitle, anime.bangumiId, server },
+                })
+                ctx.total_count = (ctx.total_count or 0) + 1
+            end
+        end
+        local display_items = {}
+        if ctx.remaining.n > 0 then
+            table.insert(display_items, {
+                title = ctx.message,
+                value = "",
+                italic = true,
+                keep_open = true,
+                selectable = false,
+                icon = "spinner",
+            })
+        end
+        -- 按 server_order 拼接当前已收到的结果
+        for _, srv in ipairs(ctx.server_order or {}) do
+            local list = ctx.server_items and ctx.server_items[srv]
+            if list and type(list) == 'table' then
+                for _, v in ipairs(list) do table.insert(display_items, v) end
+            end
+        end
+
+        if uosc_available then
+            latest_menu_anime = update_menu_uosc(ctx.menu_type, ctx.menu_title, display_items, ctx.footnote, ctx.menu_cmd, ctx.query,
+                { "script-message-to", mp.get_script_name(), "cancel-active-request", ctx.menu_type })
+        else
+            if not ctx.first_opened.val and input_loaded and (ctx.total_count or 0) > 0 then
+                ctx.first_opened.val = true
+                show_message("", 0)
+                input.terminate()
+                mp.add_timeout(0.1, function()
+                    latest_menu_anime = utils.format_json(display_items)
+                    open_menu_select(display_items)
+                end)
+            end
+        end
+
+        ctx.remaining.n = math.max(0, ctx.remaining.n - 1)
+        if ctx.remaining.n == 0 then
+            pcall(do_final_update)
+        end
+    end
+end
 
 -- 打开番剧数据匹配菜单
 function get_animes(query)
     local encoded_query = url_encode(query)
-    local url = options.api_server .. "/api/v2/search/anime"
-    local params = "keyword=" .. encoded_query
-    local full_url = url .. "?" .. params
+    local server_metas = get_api_server_list(options.api_server, true)
+    local servers = {}
+    local server_notes = {}
+    for _, m in ipairs(server_metas) do
+        table.insert(servers, m.url)
+        if m.note and m.note ~= '' then
+            server_notes[m.url] = m.note
+        end
+    end
+
     local items = {}
+    local seen = {}
+    local first_opened = false
+    local remaining = #servers
+    local server_items = {}
+    local server_order = servers
+    local total_count = 0
+    request_cancelled = false
 
     local message = "加载数据中..."
     local menu_type = "menu_anime"
@@ -20,69 +188,66 @@ function get_animes(query)
     local footnote = "使用enter或ctrl+enter进行搜索"
     local menu_cmd = { "script-message-to", mp.get_script_name(), "search-anime-event" }
     if uosc_available then
-        update_menu_uosc(menu_type, menu_title, message, footnote, menu_cmd, query)
+        active_request_type = menu_type
+        update_menu_uosc(menu_type, menu_title, message, footnote, menu_cmd, query,
+            { "script-message-to", mp.get_script_name(), "cancel-active-request", menu_type })
     else
         show_message(message, 30)
     end
-    msg.verbose("尝试获取番剧数据：" .. full_url)
 
-    local args = make_danmaku_request_args("GET", full_url)
+    msg.verbose("尝试获取番剧数据，servers: " .. table.concat(servers, ", ") .. " query: " .. query)
 
-    if args == nil then
-        return
-    end
+    local build_args = make_build_args(encoded_query)
 
-    local res = mp.command_native({ name = 'subprocess', capture_stdout = true, capture_stderr = true, args = args })
+    -- 构造 ctx，用于 handle_response 闭包访问和修改共享状态
+    local ctx = {
+        items = items,
+        seen = seen,
+        first_opened = { val = first_opened },
+        remaining = { n = remaining },
+        message = message,
+        menu_type = menu_type,
+        menu_title = menu_title,
+        footnote = footnote,
+        menu_cmd = menu_cmd,
+        query = query,
+        server_items = server_items,
+        server_order = server_order,
+        server_notes = server_notes,
+        total_count = total_count,
+    }
 
-    if not res.status or res.status ~= 0 then
-        local message = "获取数据失败"
-        if uosc_available then
-            update_menu_uosc(menu_type, menu_title, message, footnote, menu_cmd, query)
-        else
-            show_message(message, 3)
+    local handle_response = make_handle_response(ctx)
+
+    local cancel_fn = parallel_requests(servers, build_args, handle_response, function()
+        if request_cancelled then return end
+        local final_items = {}
+        for _, srv in ipairs(ctx.server_order or {}) do
+            local list = ctx.server_items and ctx.server_items[srv]
+            if list and type(list) == 'table' then
+                for _, v in ipairs(list) do table.insert(final_items, v) end
+            end
         end
-        msg.error("HTTP 请求失败：" .. res.stderr)
-    end
-
-    local response = utils.parse_json(res.stdout)
-
-    if not response or not response.animes then
-        local message = "无结果"
         if uosc_available then
-            update_menu_uosc(menu_type, menu_title, message, footnote, menu_cmd, query)
+            latest_menu_anime = update_menu_uosc(ctx.menu_type, ctx.menu_title, final_items, ctx.footnote, ctx.menu_cmd, ctx.query)
         else
-            show_message(message, 3)
+            latest_menu_anime = utils.format_json(final_items)
+            if not ctx.first_opened.val and input_loaded and #final_items > 0 then
+                ctx.first_opened.val = true
+                show_message("", 0)
+                input.terminate()
+                mp.add_timeout(0.1, function()
+                    open_menu_select(final_items)
+                end)
+            end
         end
-        msg.info("无结果")
-        return
-    end
-
-    for _, anime in ipairs(response.animes) do
-        table.insert(items, {
-            title = anime.animeTitle,
-            hint = anime.typeDescription,
-            value = {
-                "script-message-to",
-                mp.get_script_name(),
-                "search-episodes-event",
-                anime.animeTitle, anime.bangumiId,
-            },
-        })
-    end
-
-    if uosc_available then
-        latest_menu_anime = update_menu_uosc(menu_type, menu_title, items, footnote, menu_cmd, query)
-    elseif input_loaded then
-        show_message("", 0)
-        mp.add_timeout(0.1, function()
-            latest_menu_anime = utils.format_json(items)
-            open_menu_select(items)
-        end)
-    end
+    end, { concurrency = 5, per_request_timeout = 30 })
+    active_request_cancel = cancel_fn
+    active_request_type = menu_type
 end
 
-function get_episodes(animeTitle, bangumiId)
-    local url = options.api_server .. "/api/v2/bangumi/" .. bangumiId
+function get_episodes(animeTitle, bangumiId, api_server)
+    local url = api_server .. "/api/v2/bangumi/" .. bangumiId
     local items = {}
 
     local message = "加载数据中..."
@@ -91,7 +256,9 @@ function get_episodes(animeTitle, bangumiId)
     local footnote = "使用 / 打开筛选"
 
     if uosc_available then
-        update_menu_uosc(menu_type, menu_title, message, footnote)
+        active_request_type = menu_type
+        update_menu_uosc(menu_type, menu_title, message, footnote, nil, nil,
+            { "script-message-to", mp.get_script_name(), "cancel-active-request", menu_type })
     else
         show_message(message, 30)
     end
@@ -102,60 +269,70 @@ function get_episodes(animeTitle, bangumiId)
         return
     end
 
-    local res = mp.command_native({ name = 'subprocess', capture_stdout = true, capture_stderr = true, args = args })
-
-    if not res.status or res.status ~= 0 then
-        local message = "获取数据失败"
-        if uosc_available then
-            update_menu_uosc(menu_type, menu_title, message, footnote)
-        else
-            show_message(message, 3)
+    request_cancelled = false
+    active_request_type = menu_type
+    active_request_cancel = call_cmd_async(args, function(err, stdout)
+        active_request_cancel = nil
+        if request_cancelled then
+            return
         end
-        msg.error("HTTP 请求失败：" .. res.stderr)
-    end
 
-    local response = utils.parse_json(res.stdout)
-
-    if not response or not response.bangumi or not response.bangumi.episodes then
-        local message = "无结果"
-        if uosc_available then
-            update_menu_uosc(menu_type, menu_title, message, footnote)
-        else
-            show_message(message, 3)
+        if err then
+            local message = "获取数据失败"
+            if uosc_available then
+                update_menu_uosc(menu_type, menu_title, message, footnote)
+            else
+                show_message(message, 3)
+            end
+            msg.error("HTTP 请求失败：" .. tostring(err))
+            return
         end
-        msg.info("无结果")
-        return
-    end
 
-    table.insert(items, {
-        title = "← 返回搜索结果",
-        value = { "script-message-to", mp.get_script_name(), "open-latest-menu-anime", latest_menu_anime },
-        keep_open = false,
-        selectable = true,
-    })
+        local response = utils.parse_json(stdout)
+        if not response or not response.bangumi or not response.bangumi.episodes then
+            local message = "无结果"
+            if uosc_available then
+                update_menu_uosc(menu_type, menu_title, message, footnote)
+            else
+                show_message(message, 3)
+            end
+            msg.info("无结果")
+            return
+        end
 
-    for _, episode in ipairs(response.bangumi.episodes) do
         table.insert(items, {
-            title = episode.episodeTitle,
-            hint = episode.episodeNumber,
-            value = { "script-message-to", mp.get_script_name(), "load-danmaku",
-            animeTitle, episode.episodeTitle, episode.episodeId },
+            title = "← 返回搜索结果",
+            value = { "script-message-to", mp.get_script_name(), "open-latest-menu-anime", latest_menu_anime },
             keep_open = false,
             selectable = true,
         })
-    end
 
-    if uosc_available then
-        footnote = mp.get_property("filename")
-        update_menu_uosc(menu_type, menu_title, items, footnote)
-    elseif input_loaded then
-        mp.add_timeout(0.1, function()
-            open_menu_select(items)
-        end)
-    end
+        for _, episode in ipairs(response.bangumi.episodes) do
+            table.insert(items, {
+                title = episode.episodeTitle,
+                hint = episode.episodeNumber,
+                value = { "script-message-to", mp.get_script_name(), "load-danmaku",
+                animeTitle, episode.episodeTitle, episode.episodeId, api_server },
+                keep_open = false,
+                selectable = true,
+            })
+        end
+
+        if uosc_available then
+            footnote = mp.get_property("filename")
+            update_menu_uosc(menu_type, menu_title, items, footnote)
+        elseif input_loaded then
+            show_message("", 0)
+            input.terminate()
+            mp.add_timeout(0.1, function()
+                open_menu_select(items)
+            end)
+        end
+    end)
+    active_request_type = menu_type
 end
 
-function update_menu_uosc(menu_type, menu_title, menu_item, menu_footnote, menu_cmd, query)
+function update_menu_uosc(menu_type, menu_title, menu_item, menu_footnote, menu_cmd, query, on_close)
     local items = {}
     if type(menu_item) == "string" then
         table.insert(items, {
@@ -181,8 +358,19 @@ function update_menu_uosc(menu_type, menu_title, menu_item, menu_footnote, menu_
         search_suggestion = query,
         items = items,
     }
+
+    if on_close ~= nil then
+        menu_props.on_close = on_close
+    end
+
+    local current_menu_type = mp.get_property_native('user-data/uosc/menu/type')
+    local cmd = "open-menu"
+    if current_menu_type and tostring(current_menu_type) == tostring(menu_type) then
+        cmd = "update-menu"
+    end
+
     local json_props = utils.format_json(menu_props)
-    mp.commandv("script-message-to", "uosc", "open-menu", json_props)
+    mp.commandv("script-message-to", "uosc", cmd, json_props)
 
     return json_props
 end
@@ -196,10 +384,22 @@ function open_menu_select(menu_items, is_time)
     end
     mp.commandv('script-message-to', 'console', 'disable')
     input.select({
-        prompt = '筛选:',
+        prompt = is_time and '筛选:' or '选择:',
         items = item_titles,
         submit = function(id)
-            mp.commandv(unpack(item_values[id]))
+            input.terminate()
+            perform_cancel_active_request()
+            local v = item_values[id]
+            if type(v) == 'table' then
+                mp.commandv(unpack(v))
+            elseif type(v) == 'string' then
+                mp.command(v)
+            end
+        end,
+        closed = function()
+            show_message("", 0)
+            input.terminate()
+            perform_cancel_active_request()
         end,
     })
 end
@@ -277,23 +477,29 @@ function open_add_menu_get()
         local serial = 0
         for url, source in pairs(DANMAKU.sources) do
             if source.data then
-                serial = serial + 1
-                local action, text
-
                 if source.from == "api_server" then
-                    action = source.blocked and "unblock" or "block"
-                    text = string.format("  [%02d] %s [来源：弹幕服务器%s]  ", serial, url,
+                    serial = serial + 1
+                    local action = source.blocked and "unblock" or "block"
+                    local text = string.format("  [%02d] %s [来源：弹幕服务器%s]  ", serial, url,
                         source.blocked and "（已屏蔽）" or "（未屏蔽）")
+                    local style = (tonumber(select_num) == serial) and "{\\c&HFFDE7F&\\b1}" or (action == "unblock" and "{\\c&H4C4CC3&\\b0}" or "{\\c&HCCCCCC&\\b0}")
+                    deal_value[serial] = {value = url, action = action}
+                    table.insert(menu_log, {text = text, style = style})
                 else
-                    action = "delete"
-                    text = string.format("  [%02d] %s [来源：用户添加]  ", serial, url)
+                    serial = serial + 1
+                    local action1 = source.blocked and "unblock" or "block"
+                    local text1 = string.format("  [%02d] %s [来源：用户添加]%s  ", serial, url, source.blocked and " (已屏蔽)" or "（未屏蔽）")
+                    local style1 = (tonumber(select_num) == serial) and "{\\c&HFFDE7F&\\b1}" or (action1 == "unblock" and "{\\c&H4C4CC3&\\b0}" or "{\\c&HCCCCCC&\\b0}")
+                    deal_value[serial] = {value = url, action = action1}
+                    table.insert(menu_log, {text = text1, style = style1})
+
+                    serial = serial + 1
+                    local action2 = "delete"
+                    local text2 = string.format("  [%02d] %s [来源：用户添加] (删除)  ", serial, url)
+                    local style2 = (tonumber(select_num) == serial) and "{\\c&HFFDE7F&\\b1}" or "{\\c&HCCCCCC&\\b0}"
+                    deal_value[serial] = {value = url, action = action2}
+                    table.insert(menu_log, {text = text2, style = style2})
                 end
-
-                local style = (tonumber(select_num) == serial) and
-                    "{\\c&HFFDE7F&\\b1}" or (action == "unblock" and "{\\c&H4C4CC3&\\b0}" or "{\\c&HCCCCCC&\\b0}")
-
-                deal_value[serial] = {value = url, action = action}
-                table.insert(menu_log, {text = text, style = style})
             end
         end
 
@@ -380,7 +586,7 @@ function open_add_menu_uosc()
     local sources = {}
     for url, source in pairs(DANMAKU.sources) do
         if source.data then
-            local item = {title = url, value = url, keep_open = true,}
+            local item = {title = utf8_sub(url, 1, 100), value = url, keep_open = true,}
             if source.from == "api_server" then
                 if source.blocked then
                     item.hint = "来源：弹幕服务器（已屏蔽）"
@@ -391,7 +597,17 @@ function open_add_menu_uosc()
                 end
             else
                 item.hint = "来源：用户添加"
-                item.actions = {{icon = "delete", name = "delete", label = "删除"},}
+                if source.blocked then
+                    item.actions = {
+                        {icon = "check", name = "unblock", label = "解除屏蔽"},
+                        {icon = "delete", name = "delete", label = "删除"},
+                    }
+                else
+                    item.actions = {
+                        {icon = "not_interested", name = "block", label = "屏蔽"},
+                        {icon = "delete", name = "delete", label = "删除"},
+                    }
+                end
             end
             table.insert(sources, item)
         end
@@ -428,13 +644,24 @@ function open_content_menu(pos)
     if COMMENTS ~= nil then
         for _, event in ipairs(COMMENTS) do
             local text = event.clean_text:gsub("^m%s[mbl%s%-%d%.]+$", ""):gsub("^%s*(.-)%s*$", "%1")
-            local delay = get_delay_for_time(DELAYS, event.start_time)
-            local start_time = event.start_time + delay
-            local end_time = event.end_time + delay
+            local delay = event.delay
+            local start_time = event.start_time
+            local end_time = event.end_time
             if text and text ~= "" and start_time >= 0 and start_time <= duration then
+                local delay_label_suffix = nil
+                local delay_num = delay and tonumber(delay)
+                if delay_num and math.abs(delay_num) > 0 then
+                    delay_label_suffix = string.format("已存在延迟: %+0.1fs", delay_num)
+                end
+
+                local adjust_label = '调整弹幕延迟'
+                if delay_label_suffix then
+                    adjust_label = adjust_label .. '（' .. delay_label_suffix .. '）'
+                end
+
                 table.insert(items, {
                     title = abbr_str(text, 60),
-                    hint = seconds_to_time(start_time) .. "(" .. remove_query(event.source) .. ")",
+                    hint = seconds_to_time(start_time) .. "  (" .. utf8_sub(remove_query(event.source), 1, 70) .. ")",
                     actions = {
                         {
                             name = 'block_source',
@@ -444,7 +671,7 @@ function open_content_menu(pos)
                         {
                             name = 'adjust_delay',
                             icon = 'more_time',
-                            label = '调整弹幕源延迟'
+                            label = adjust_label,
                         },
                     },
                     value = { "seek", start_time, "absolute" },
@@ -683,6 +910,93 @@ function open_style_menu(actived, status)
     end
 end
 
+-- 打开以指定时间为起点的延迟菜单
+function open_delay_from_time_get(source, time, status)
+    mp.commandv('script-message-to', 'console', 'disable')
+    local menu_log = {}
+
+    local function build_menu(query, input_text)
+        menu_log = {
+            { text = "【从该时间起调整弹幕延迟】", style = "{\\c&H00CCFF&\\b1}" },
+            { text = ("-"):rep(33), style = "{\\c&H888888&}" }
+        }
+
+        table.insert(menu_log, { text = "\n", style = "" })
+        local hint_text = "提示：请输入数字，单位（秒）/ 或者按照形如\"14m15s\"的格式输入分钟数加秒数"
+        local hint_style = "{\\c&H999999&}"
+        if status == "error" then
+            hint_text = "提示: 输入非数字字符或范围出错"
+            hint_style = "{\\c&H4C4CC3&}"
+        end
+
+        table.insert(menu_log, { text = input_text and ("已输入：" .. input_text) or "", style = "{\\c&HCCCCCC&}" })
+        table.insert(menu_log, { text = hint_text, style = hint_style })
+        input.set_log(menu_log)
+    end
+
+    input.get({
+        keep_open = true,
+        prompt = "请输入要设置的延迟（秒或 XmYs）: ",
+        opened = function() build_menu() end,
+        edited = function(text)
+            text = text:gsub("^%s*(.-)%s*$", "%1")
+            if text == "" then
+                build_menu()
+                return
+            end
+            build_menu(text)
+        end,
+        submit = function(text)
+            text = text and text:gsub("^%s*(.-)%s*$", "%1") or ""
+            if text == "" then return end
+            input.terminate()
+            local parsed = parse_delay_input(text)
+            if parsed ~= nil then
+                mp.commandv("script-message", "danmaku-delay", tostring(parsed), tostring(time), tostring(source))
+            else
+                open_delay_from_time(time, "error")
+            end
+        end
+    })
+end
+
+function open_delay_from_time_uosc(source, time, status)
+    if not uosc_available then
+        show_message("无uosc UI框架，不支持使用该功能", 2)
+        return
+    end
+
+    local menu_props = {
+        type = "menu_delay_from_time",
+        title = "从该时间起调整弹幕延迟",
+        search_style = "palette",
+        search_debounce = "submit",
+        footnote = "请输入数字，单位（秒）/ 或者按照形如\"14m15s\"的格式输入分钟数加秒数",
+        items = {},
+        on_search = { "script-message-to", mp.get_script_name(), "setup-content-delay", tostring(time), tostring(source) },
+    }
+
+    if status == "error" then
+    menu_props.title = "输入非数字字符或范围出错"
+    mp.add_timeout(1.0, function() open_delay_from_time_uosc(source, time) end)
+    end
+
+    local json_props = utils.format_json(menu_props)
+    mp.commandv("script-message-to", "uosc", "open-menu", json_props)
+end
+
+function open_delay_from_time(source, time, status)
+    if uosc_available then
+        open_delay_from_time_uosc(source, time, status)
+    elseif input_loaded then
+        mp.add_timeout(0.01, function()
+            open_delay_from_time_get(source, time, status)
+        end)
+    else
+        show_message("无支持可用的 UI框架，不支持使用该功能", 3)
+    end
+end
+
 -- 设置弹幕源延迟菜单
 function open_delay_menu_get(source, status)
     mp.commandv('script-message-to', 'console', 'disable')
@@ -701,7 +1015,7 @@ function open_delay_menu_get(source, status)
             { text = ("-"):rep(33), style = "{\\c&H888888&}" }
         }
 
-        serial = 0
+        serial, select_num = 0, 0
         for url, src in pairs(DANMAKU.sources) do
             if src.data and not src.blocked then
                 local delay = 0
@@ -811,7 +1125,7 @@ function open_delay_menu_uosc(source_url, status)
                     end
                 end
             end
-            local item = {title = url, value = url, keep_open = true,}
+            local item = {title = utf8_sub(url, 1, 100), value = url, keep_open = true,}
             item.hint = "当前弹幕源延迟:" .. string.format("%.1f", delay + 1e-10) .. "秒"
             item.active = url == source_url
             table.insert(sources, item)
@@ -842,12 +1156,12 @@ function open_delay_menu_uosc(source_url, status)
     mp.commandv("script-message-to", "uosc", "open-menu", json_props)
 end
 
-function open_delay_menu(source, query)
+function open_delay_menu(source, status)
     if uosc_available then
-        open_delay_menu_uosc(source, query)
+        open_delay_menu_uosc(source, status)
     elseif input_loaded then
         mp.add_timeout(0.01, function()
-            open_delay_menu_get(source, query)
+            open_delay_menu_get(source, status)
         end)
     else
         show_message("无支持可用的 UI框架，不支持使用该功能", 3)
@@ -1015,6 +1329,7 @@ end)
 
 -- 注册函数给 uosc 按钮使用
 mp.register_script_message("search-anime-event", function(query)
+    perform_cancel_active_request()
     if uosc_available then
         mp.commandv("script-message-to", "uosc", "close-menu", "menu_danmaku")
     end
@@ -1025,19 +1340,20 @@ mp.register_script_message("search-anime-event", function(query)
         get_animes(query)
     end
 end)
-mp.register_script_message("search-episodes-event", function(animeTitle, bangumiId)
+mp.register_script_message("search-episodes-event", function(animeTitle, bangumiId, api_server)
+    perform_cancel_active_request()
     if uosc_available then
         mp.commandv("script-message-to", "uosc", "close-menu", "menu_anime")
     end
-    get_episodes(animeTitle, bangumiId)
+
+    get_episodes(animeTitle, bangumiId, api_server)
 end)
 
--- Register script message to show the input menu
-mp.register_script_message("load-danmaku", function(animeTitle, episodeTitle, episodeId)
+mp.register_script_message("load-danmaku", function(animeTitle, episodeTitle, episodeId, api_server)
     ENABLED = true
     DANMAKU.anime = animeTitle
     DANMAKU.episode = episodeTitle
-    set_episode_id(episodeId, true)
+    set_episode_id(episodeId, true, api_server)
 end)
 
 mp.register_script_message("add-source-event", function(query)
@@ -1071,6 +1387,10 @@ mp.register_script_message("open-latest-menu-anime", function ()
             open_menu_select(utils.parse_json(latest_menu_anime))
         end)
     end
+end)
+
+mp.register_script_message('cancel-active-request', function(menu_type)
+    perform_cancel_active_request(menu_type)
 end)
 
 mp.register_script_message("setup-danmaku-style", function(query, text)
@@ -1167,32 +1487,13 @@ mp.register_script_message("setup-source-delay", function(query, text)
         if text == nil or text == "" then
             return
         end
-        local newText, _ = text:gsub("%s", "") -- 移除所有空白字符
-        local num = tonumber(newText)
-        local delay_segments = shallow_copy(DANMAKU.sources[query]["delay_segments"] or {})
-        for i = #delay_segments, 1, -1 do
-            if delay_segments[i].start == 0 then
-                table.remove(delay_segments, i)
-            end
-        end
-        if num ~= nil then
-            table.insert(delay_segments, 1, { start = 0, delay = tonumber(num) })
-            DANMAKU.sources[query]["delay_segments"] = delay_segments
-            add_source_to_history(query, DANMAKU.sources[query])
+        local delay = parse_delay_input(text)
+        if delay ~= nil then
+            mp.commandv("script-message", "danmaku-delay", tostring(delay), "0", tostring(query))
             mp.commandv("script-message-to", "uosc", "close-menu", "menu_delay")
-            open_delay_menu(query, "refresh")
-            load_danmaku(true, true)
-        elseif newText:match("^%-?%d+m%d+s$") then
-            local minutes, seconds = string.match(newText, "^(%-?%d+)m(%d+)s$")
-            minutes = tonumber(minutes)
-            seconds = tonumber(seconds)
-            if minutes < 0 then seconds = -seconds end
-            table.insert(delay_segments, 1, { start = 0, delay = 60 * minutes + seconds })
-            DANMAKU.sources[query]["delay_segments"] = delay_segments
-            add_source_to_history(query, DANMAKU.sources[query])
-            mp.commandv("script-message-to", "uosc", "close-menu", "menu_delay")
-            open_delay_menu(query, "refresh")
-            load_danmaku(true, true)
+            mp.add_timeout(0.1, function()
+                open_delay_menu(query, "refresh")
+            end)
         else
             open_delay_menu(query, "error")
         end
@@ -1213,7 +1514,8 @@ mp.register_script_message('handle-danmaku-content-action', function(json)
             mp.commandv("script-message-to", "uosc", "close-menu", "menu_content")
             load_danmaku(true)
         elseif event.action == "adjust_delay" then
-            mp.commandv("script-message", "open_source_delay_menu", d.source)
+            -- 打开以该弹幕时间为起点的延迟菜单（该延迟将作用于该时间点及之后的弹幕），仅针对该条弹幕的 source
+            mp.commandv("script-message", "open_content_delay_menu", d.source, tostring(d.start_time))
         end
     else
         if event.value then
@@ -1223,6 +1525,29 @@ mp.register_script_message('handle-danmaku-content-action', function(json)
                 mp.command(event.value)
             end
             mp.commandv("script-message-to", "uosc", "close-menu", "menu_content")
+        end
+    end
+end)
+
+mp.register_script_message("open_content_delay_menu", function(source, time)
+    open_delay_from_time(source, tonumber(time))
+end)
+
+mp.register_script_message("setup-content-delay", function(...)
+    local args = {...}
+    if #args == 1 then
+        return
+    end
+    if #args >= 2 then
+        local time = tonumber(args[1])
+        local source = args[2]
+        local delay_str = args[3]
+        local delay = parse_delay_input(delay_str)
+        if delay ~= nil then
+            mp.commandv("script-message", "danmaku-delay", tostring(delay), tostring(time), tostring(source))
+            mp.commandv("script-message-to", "uosc", "close-menu", "menu_delay_from_time")
+        else
+            open_delay_from_time(source, tonumber(time), "error")
         end
     end
 end)

--- a/scripts/uosc_danmaku/modules/options.lua
+++ b/scripts/uosc_danmaku/modules/options.lua
@@ -3,21 +3,24 @@ local opt = require("mp.options")
 -- 选项
 options = {
     -- 指定弹幕服务器地址，自定义服务需兼容 dandanplay 的 api
+    -- 可指定多个用逗号分隔的有序 api_server 列表
+    -- 支持每项使用 '|' 或 '#' 分隔备注，例如: "https://a.example.com|备用A" 或 "https://b.example.com#备用B"
     api_server = "https://api.dandanplay.net",
     -- 指定 b 站和爱腾优的弹幕获取的兜底服务器地址，主要用于获取非动画弹幕
-    -- 服务器可以自托管：https://github.com/lyz05/danmaku
-    fallback_server = "https://fc.lyz05.cn",
+    -- 可用： https://api.danmu.icu，https://dmku.hls.one
+    fallback_server = "https://api.danmu.icu",
     -- 设置 tmdb 的 API Key，用于获取非动画条目的中文信息(当搜索内容非中文时)
     -- 可以在 https://www.themoviedb.org 注册后去个人账号设置界面获取
     -- 注意：自定义此参数时还需要对获取到的 API Key 进行 base64 编码
     tmdb_api_key = "NmJmYjIxOTZkNzIyN2UyMTIzMGM3Y2YzZjQ4MDNkZGM=",
-    load_more_danmaku = false,
     auto_load = false,
     autoload_local_danmaku = false,
     autoload_for_url = false,
     save_danmaku = false,
     user_agent = "mpv_danmaku/1.0",
     proxy = "",
+    -- 可选：向 HTTP 请求传递 cookie.txt 文件路径
+    cookie_file = "",
     -- 使用 fps 视频滤镜，大幅提升弹幕平滑度。默认禁用
     vf_fps = false,
     -- 设置要使用的 fps 滤镜参数
@@ -69,11 +72,6 @@ options = {
     -- 指定哈希匹配中需忽略的共享盘（挂载盘）的路径/目录。支持绝对路径和相对路径，多个路径用逗号分隔
     -- 示例：["X:", "Z:", "F:/Download/", "Download"]
     excluded_path = [[
-        []
-    ]],
-    -- 排除指定平台的弹幕源，支持域名关键词匹配。多个平台用逗号分隔
-    -- 示例：["bilibili.com", "gamer.com.tw"]
-    excluded_platforms = [[
         []
     ]],
 }

--- a/scripts/uosc_danmaku/modules/parse.lua
+++ b/scripts/uosc_danmaku/modules/parse.lua
@@ -10,6 +10,33 @@ local function ass_escape(text)
                :gsub("\n", "\\N")
 end
 
+-- 构建 per-source 的延迟查询函数
+local function make_delay_lookup(source)
+    local segments = nil
+    local prefix = nil
+    if source and source.delay_segments and #source.delay_segments > 0 then
+        segments = {}
+        for i, v in ipairs(source.delay_segments) do segments[i] = v end
+        table.sort(segments, function(a, b) return (a.start or 0) < (b.start or 0) end)
+        prefix = {}
+        local s = 0
+        for i, v in ipairs(segments) do
+            s = s + (v.delay or 0)
+            prefix[i] = s
+        end
+    end
+
+    return function(t)
+        local segs = segments or {}
+        local pre = prefix or {}
+        if #segs == 0 then return 0 end
+        local idx = binary_search(segs, t, function(s) return (s and s.start) or 0 end)
+        local target = idx - 1
+        if target < 1 then return 0 end
+        return pre[target] or 0
+    end
+end
+
 local function xml_unescape(str)
     return str:gsub("&quot;", "\"")
               :gsub("&apos;", "'")
@@ -40,10 +67,50 @@ local function load_blacklist_patterns(filepath)
         return patterns
     end
 
-    for line in file:lines() do
-        line = line:match("^%s*(.-)%s*$")
-        if line ~= "" then
-            table.insert(patterns, line)
+    if string.match(filepath, "%.xml$") then
+        -- xml文件格式示例
+        --<?xml version="1.0" encoding="utf-8"?>
+        --<filters>
+        --  <item enabled="true">t=卡在</item>
+        --  <item enabled="true">t=进度条</item>
+        --</filters>
+        print("加载黑名单文件: " .. filepath)
+        for line in file:lines() do
+            local pattern = line:match('<item%s+enabled="true">t=(.-)</item>')
+            if pattern then
+                print("加载黑名单模式: " .. pattern)
+                table.insert(patterns, pattern)
+            end
+        end
+    end
+
+    if string.match(filepath, "%.json$") then
+        -- json文件格式示例
+        -- [{"type":0,"filter":"开门","opened":true,"id":15628936}
+        -- ,{"type":0,"filter":"tony","opened":true,"id":15628939}
+        -- ,{"type":1,"filter":"0+.1","opened":true,"id":15628951}]
+        local content = read_file(filepath)
+        if content then
+            local json = utils.parse_json(content)
+            if json and type(json) == "table" then
+                for _, entry in ipairs(json) do
+                    if entry.opened and entry.filter and entry.type == 0 then
+                        table.insert(patterns, entry.filter)
+                    end
+                end
+            end
+        end
+    end
+
+    if string.match(filepath, "%.txt$") then
+        -- 文本文件格式示例
+        -- 卡在
+        -- 进度条
+        for line in file:lines() do
+            line = line:match("^%s*(.-)%s*$")
+            if line ~= "" then
+                table.insert(patterns, line)
+            end
         end
     end
 
@@ -114,51 +181,62 @@ local function merge_duplicate_danmaku(danmakus, threshold)
     local groups = {}
 
     for _, d in ipairs(danmakus) do
-        local key = d.type .. "|" .. d.color .. "|" .. d.text
-        if not groups[key] then groups[key] = {} end
-        table.insert(groups[key], d)
+        local tkey = tostring(d.type or "")
+        local ckey = tostring(d.color or "")
+        local text = d.text or ""
+
+        groups[tkey] = groups[tkey] or {}
+        groups[tkey][ckey] = groups[tkey][ckey] or {}
+        groups[tkey][ckey][text] = groups[tkey][ckey][text] or {}
+        table.insert(groups[tkey][ckey][text], d)
     end
 
     local merged = {}
+    local abs = math.abs
 
-    for _, group in pairs(groups) do
-        table.sort(group, function(a, b) return a.time < b.time end)
+    for _, bytype in pairs(groups) do
+        for _, bycolor in pairs(bytype) do
+            for _, group in pairs(bycolor) do
+                table.sort(group, function(a, b) return a.time < b.time end)
 
-        local i = 1
-        while i <= #group do
-            local base = group[i]
-            local times = { base.time }
-            local count = 1
-            local j = i + 1
+                local i = 1
+                while i <= #group do
+                    local base = group[i]
+                    local times = { base.time }
+                    local count = 1
+                    local j = i + 1
 
-            while j <= #group and math.abs(group[j].time - base.time) <= threshold do
-                table.insert(times, group[j].time)
-                count = count + 1
-                j = j + 1
-            end
+                    while j <= #group and abs(group[j].time - base.time) <= threshold do
+                        times[#times+1] = group[j].time
+                        count = count + 1
+                        j = j + 1
+                    end
 
-            local same_time = true
-            for k = 2, #times do
-                if times[k] ~= times[1] then
-                    same_time = false
-                    break
+                    local same_time = true
+                    for k = 2, #times do
+                        if times[k] ~= times[1] then
+                            same_time = false
+                            break
+                        end
+                    end
+
+                    local danmaku = {
+                        time = base.time,
+                        type = base.type,
+                        size = base.size,
+                        color = base.color,
+                        text = base.text,
+                        source = base.source,
+                        orig_time = base.orig_time,
+                    }
+                    if count > 2 or not same_time then
+                        danmaku.text = danmaku.text .. string.format("x%d", count)
+                    end
+
+                    table.insert(merged, danmaku)
+                    i = j
                 end
             end
-
-            local danmaku = {
-                time = base.time,
-                type = base.type,
-                size = base.size,
-                color = base.color,
-                text = base.text,
-                source = base.source,
-            }
-            if count > 2 or not same_time then
-                danmaku.text = danmaku.text .. string.format("x%d", count)
-            end
-
-            table.insert(merged, danmaku)
-            i = j
         end
     end
 
@@ -290,18 +368,17 @@ function parse_danmaku_file(danmaku_input)
             end
 
             for _, d in ipairs(parsed) do
-                local matched, pattern = is_blacklisted(d.text, black_patterns)
-                if not matched then
-                    table.insert(danmakus, d)
-                else
-                    -- msg.debug("命中黑名单: " .. pattern)
-                end
+                table.insert(danmakus, d)
             end
         else
             msg.info("无法读取文件内容: " .. danmaku_input)
         end
     else
         msg.info("文件不存在: " .. danmaku_input)
+    end
+
+    for _, d in ipairs(danmakus) do
+        if d.orig_time == nil then d.orig_time = d.time end
     end
 
     if #danmakus == 0 then
@@ -419,10 +496,22 @@ end
 -- 将弹幕转换为 XML 格式
 function convert_danmaku_to_xml(danmaku_out)
     local danmakus = {}
-    for _, source in pairs(DANMAKU.sources) do
+    for url, source in pairs(DANMAKU.sources) do
         if not source.blocked and source.data then
+            local get_cached_delay = make_delay_lookup(source)
+
             for _, d in ipairs(source.data) do
-                table.insert(danmakus, d)
+                local base_time = d.orig_time or d.time
+                local adjusted_time = base_time + get_cached_delay(base_time)
+                table.insert(danmakus, {
+                    orig_time = d.orig_time,
+                    time = adjusted_time,
+                    type = d.type,
+                    size = d.size,
+                    color = d.color,
+                    text = d.text,
+                    source = url,
+                })
             end
         end
     end
@@ -467,17 +556,57 @@ function convert_danmaku_to_xml(danmaku_out)
     return true
 end
 
-function convert_danmaku_to_ass_events()
-    local danmakus = {}
+function convert_danmaku_to_ass_events(force)
+    local per_source_lists = {}
     for url, source in pairs(DANMAKU.sources) do
         if not source.blocked and source.data then
+            local get_cached_delay = make_delay_lookup(source)
+
+            local list = {}
             for _, d in ipairs(source.data) do
-                local delay_segments = (source.delay_segments and #source.delay_segments > 0) and source.delay_segments or {}
-                local delay = get_delay_for_time(delay_segments, d.time)
-                d.time = d.time + delay
-                d.source = url
-                table.insert(danmakus, d)
+                local base_time = d.orig_time or d.time
+                if d.orig_time == nil then d.orig_time = base_time end
+                local adjusted_time = base_time + get_cached_delay(base_time)
+                local entry = {
+                    orig_time = d.orig_time,
+                    time = adjusted_time,
+                    type = d.type,
+                    size = d.size,
+                    color = d.color,
+                    text = d.text,
+                    source = url,
+                }
+                if not is_blacklisted(d.text, black_patterns) then
+                    table.insert(list, entry)
+                end
             end
+
+            if #list > 0 then
+                table.sort(list, function(a, b) return a.time < b.time end)
+                per_source_lists[#per_source_lists + 1] = list
+            end
+        end
+    end
+
+    local danmakus = {}
+
+    local heap = new_min_heap()
+    for li = 1, #per_source_lists do
+        local lst = per_source_lists[li]
+        if lst and #lst > 0 then
+            heap.push({ time = lst[1].time, list_idx = li, pos = 1, entry = lst[1] })
+        end
+    end
+
+    while true do
+        local node = heap.pop()
+        if not node then break end
+        table.insert(danmakus, node.entry)
+        local li = node.list_idx
+        local next_pos = node.pos + 1
+        local lst = per_source_lists[li]
+        if lst and lst[next_pos] then
+            heap.push({ time = lst[next_pos].time, list_idx = li, pos = next_pos, entry = lst[next_pos] })
         end
     end
 
@@ -485,21 +614,20 @@ function convert_danmaku_to_ass_events()
         options.merge_tolerance = options.scrolltime
     end
 
-    -- 按时间排序
-    table.sort(danmakus, function(a, b)
-        return a.time < b.time
-    end)
-
     danmakus = merge_duplicate_danmaku(danmakus, options.merge_tolerance)
 
     if #danmakus == 0 then
-        show_message("该集弹幕内容为空，结束加载", 3)
-        msg.verbose("该集弹幕内容为空，结束加载")
+        if not force then
+            show_message("该集弹幕内容为空，结束加载", 3)
+            msg.verbose("该集弹幕内容为空，结束加载")
+        end
         COMMENTS = {}
         return
     end
 
-    msg.info("已解析 " .. #danmakus .. " 条弹幕")
+    if not force then
+        msg.info("已解析 " .. #danmakus .. " 条弹幕")
+    end
 
     local fontsize = tonumber(options.fontsize) or 50
     local scrolltime = tonumber(options.scrolltime) or 15
@@ -515,6 +643,7 @@ function convert_danmaku_to_ass_events()
     local pre_events = {}
     for _, d in ipairs(danmakus) do
         local time = d.type == 1 and math.floor(d.time + 0.5) or d.time
+        local orig_time = d.type == 1 and math.floor(d.orig_time + 0.5) or d.orig_time
         local appear_time = time
         local danmaku_type = d.type
 
@@ -526,7 +655,7 @@ function convert_danmaku_to_ass_events()
         end
 
         if end_time then
-            table.insert(pre_events, {start_time = appear_time, end_time = end_time, danmaku = d})
+            table.insert(pre_events, {orig_time = orig_time, start_time = appear_time, end_time = end_time, danmaku = d})
         end
     end
 
@@ -590,8 +719,10 @@ function convert_danmaku_to_ass_events()
         if style and effect then
             text = effect .. color_text .. text
             local event = {
+                orig_time = ev.orig_time,
                 start_time = ev.start_time,
                 end_time = ev.end_time,
+                delay = ev.start_time - (ev.orig_time or ev.start_time),
                 style = style,
                 text = text,
                 clean_text = clean_text,

--- a/scripts/uosc_danmaku/modules/render.lua
+++ b/scripts/uosc_danmaku/modules/render.lua
@@ -3,13 +3,11 @@ local msg = require('mp.msg')
 local utils = require("mp.utils")
 local unpack = unpack or table.unpack
 
-local INTERVAL = options.vf_fps and 0.01 or 0.001
 local osd_width, osd_height, pause = 0, 0, true
-
+local time_pos_observer_active = false
 local overlay = mp.create_osd_overlay('ass-events')
 
-local function realtime_position_text(event, pos, height, delay)
-    local displayarea = tonumber(height * options.displayarea)
+local function realtime_position_text(event, pos, displayarea)
     if not event.move then
         local _, current_y = unpack(event.pos)
         if not current_y or tonumber(current_y) > displayarea then return end
@@ -23,7 +21,7 @@ local function realtime_position_text(event, pos, height, delay)
     local x1, y1, x2, y2 = unpack(event.move)
     -- 计算移动的时间范围
     local duration = event.end_time - event.start_time  --mean: options.scrolltime
-    local progress = (pos - event.start_time - delay) / duration  -- 移动进度 [0, 1]
+    local progress = (pos - event.start_time) / duration  -- 移动进度 [0, 1]
 
     -- 计算当前坐标
     local current_x = tonumber(x1 + (x2 - x1) * progress)
@@ -39,19 +37,28 @@ local function realtime_position_text(event, pos, height, delay)
     end
 end
 
-function render()
+function render(pos_arg)
     if COMMENTS == nil then return end
 
-    local pos, err = mp.get_property_number('time-pos')
-    if err ~= nil then
-        return msg.error(err)
+    local pos, err
+    if pos_arg == nil then
+        pos, err = mp.get_property_number('time-pos')
+        if err ~= nil then
+            return msg.error(err)
+        end
+    else
+        pos = pos_arg
     end
 
-    local delay = get_delay_for_time(DELAYS, pos)
+    if not pos then
+        overlay:remove()
+        return
+    end
 
     local fontname = options.fontname
     local fontsize = options.fontsize
-    local alpha = string.format("%02X", (1 - tonumber(options.opacity)) * 255)
+    local opacity = tonumber(options.opacity)
+    local alpha = string.format("%02X", (1 - (opacity or 0)) * 255)
 
     local width, height = 1920, 1080
     local ratio = osd_width / osd_height
@@ -61,23 +68,37 @@ function render()
     end
 
     local ass_events = {}
+    local max_display = math.max(options.scrolltime, options.fixtime)
+    local window_start = pos - max_display
 
-    for _, event in ipairs(COMMENTS) do
-        if pos >= event.start_time + delay and pos <= event.end_time + delay then
-            local text = realtime_position_text(event, pos, height, delay)
+    -- 跳过已结束的弹幕
+    local lo = binary_search(COMMENTS, window_start, function(item) return item.start_time end)
+
+    local re_entity = "&#%d+;"
+    local re_fs = "\\fs(%d+)"
+    local ass_prefix = string.format("{\\rDefault\\fn%s\\fs%d\\c&HFFFFFF&\\alpha&H%s\\bord%s\\shad%s\\b%s\\q2}",
+        fontname, fontsize, alpha, options.outline, options.shadow, options.bold and "1" or "0")
+
+    for i = lo, #COMMENTS do
+        local event = COMMENTS[i]
+        if not event then break end
+
+        if event.start_time > pos then break end  -- 后续弹幕提前退出
+        if event.end_time >= pos then
+            local text = realtime_position_text(event, pos, height * options.displayarea)
             if text then
-                text = text:gsub("&#%d+;","")
+                text = text:gsub(re_entity, "")
             end
 
-            if text and text:match("\\fs%d+") then
-                text = text:gsub("\\fs(%d+)", function(size)
-                    return string.format("\\fs%d", size * 1.5)
+            if text and text:match(re_fs) then
+                text = text:gsub(re_fs, function(size)
+                    local n = tonumber(size) or 0
+                    return string.format("\\fs%d", math.floor(n * 1.5))
                 end)
             end
 
             -- 构建 ASS 字符串
-            local ass_text = text and string.format("{\\rDefault\\fn%s\\fs%d\\c&HFFFFFF&\\alpha&H%s\\bord%s\\shad%s\\b%s\\q2}%s",
-                fontname, fontsize, alpha, options.outline, options.shadow, options.bold and "1" or "0", text)
+            local ass_text = text and (ass_prefix .. text)
 
             table.insert(ass_events, ass_text)
         end
@@ -89,7 +110,27 @@ function render()
     overlay:update()
 end
 
-local timer = mp.add_periodic_timer(INTERVAL, render, true)
+local function time_pos_callback(_, time_pos)
+    if time_pos then
+        render(time_pos)
+    else
+        overlay:remove()
+    end
+end
+
+local function start_time_observer()
+    if not time_pos_observer_active then
+        mp.observe_property('time-pos', 'number', time_pos_callback)
+        time_pos_observer_active = true
+    end
+end
+
+local function stop_time_observer()
+    if time_pos_observer_active then
+        mp.unobserve_property(time_pos_callback)
+        time_pos_observer_active = false
+    end
+end
 
 function render_danmaku(from_menu, no_osd)
     if ENABLED and (from_menu or get_danmaku_visibility()) then
@@ -120,7 +161,7 @@ function show_danmaku_func()
     set_danmaku_visibility(true)
     render()
     if not pause then
-        timer:resume()
+        start_time_observer()
     end
     if options.vf_fps then
         local display_fps = mp.get_property_number('display-fps')
@@ -135,7 +176,7 @@ function show_danmaku_func()
 end
 
 function hide_danmaku_func()
-    timer:kill()
+    stop_time_observer()
     mp.set_property_bool(HAS_DANMAKU, false)
     set_danmaku_visibility(false)
     overlay:remove()
@@ -169,33 +210,15 @@ end
 
 mp.observe_property('osd-width', 'number', function(_, value) osd_width = value or osd_width end)
 mp.observe_property('osd-height', 'number', function(_, value) osd_height = value or osd_height end)
-mp.observe_property('display-fps', 'number', function(_, value)
-    if value ~= nil then
-        local interval = 1 / value / 10
-        if interval > INTERVAL then
-            timer:kill()
-            timer = mp.add_periodic_timer(interval, render, true)
-            if ENABLED then
-                timer:resume()
-            end
-        else
-            timer:kill()
-            timer = mp.add_periodic_timer(INTERVAL, render, true)
-            if ENABLED then
-                timer:resume()
-            end
-        end
-    end
-end)
 mp.observe_property('pause', 'bool', function(_, value)
     if value ~= nil then
         pause = value
     end
     if ENABLED then
         if pause then
-            timer:kill()
+            stop_time_observer()
         elseif COMMENTS ~= nil then
-            timer:resume()
+            start_time_observer()
         end
     end
 end)
@@ -211,7 +234,7 @@ end)
 
 mp.add_hook("on_unload", 50, function()
     COMMENTS, DELAY = nil, 0
-    timer:kill()
+    stop_time_observer()
     overlay:remove()
     mp.set_property_native(DELAY_PROPERTY, 0)
     if filter_state("danmaku") then

--- a/scripts/uosc_danmaku/modules/utils.lua
+++ b/scripts/uosc_danmaku/modules/utils.lua
@@ -211,6 +211,21 @@ function hex_to_char(x)
     return string.char(tonumber(x, 16))
 end
 
+function hex_to_int_color(hex_color)
+    -- 移除颜色代码中的'#'字符
+    hex_color = hex_color:sub(2)  -- 只保留颜色代码部分
+
+    -- 提取R, G, B的十六进制值并转为整数
+    local r = tonumber(hex_color:sub(1, 2), 16)
+    local g = tonumber(hex_color:sub(3, 4), 16)
+    local b = tonumber(hex_color:sub(5, 6), 16)
+
+    -- 计算32位整数值
+    local color_int = (r * 256 * 256) + (g * 256) + b
+
+    return color_int
+end
+
 -- url编码转换
 function url_encode(str)
     -- 将非安全字符转换为百分号编码
@@ -319,6 +334,67 @@ function file_exists(path)
     return false
 end
 
+function binary_search(tbl, target, key)
+    if not tbl or #tbl == 0 then return 1 end
+    key = key or function(x) return x end
+    local lo, hi = 1, #tbl
+    local res = #tbl + 1
+    while lo <= hi do
+        local mid = math.floor((lo + hi) / 2)
+        local v = tbl[mid]
+        local val = key(v)
+        if val >= target then
+            res = mid
+            hi = mid - 1
+        else
+            lo = mid + 1
+        end
+    end
+    return res
+end
+
+function new_min_heap()
+    local h = {}
+    local function swap(i, j)
+        h[i], h[j] = h[j], h[i]
+    end
+    local function up(i)
+        while i > 1 do
+            local p = math.floor(i/2)
+            if h[p].time <= h[i].time then break end
+            swap(p, i)
+            i = p
+        end
+    end
+    local function down(i)
+        local n = #h
+        while true do
+            local l = i * 2
+            local r = l + 1
+            local smallest = i
+            if l <= n and h[l].time < h[smallest].time then smallest = l end
+            if r <= n and h[r].time < h[smallest].time then smallest = r end
+            if smallest == i then break end
+            swap(i, smallest)
+            i = smallest
+        end
+    end
+    local function push(node)
+        h[#h + 1] = node
+        up(#h)
+    end
+    local function pop()
+        if #h == 0 then return nil end
+        local root = h[1]
+        if #h == 1 then h[1] = nil; return root end
+        h[1] = h[#h]
+        h[#h] = nil
+        down(1)
+        return root
+    end
+    return { push = push, pop = pop, size = function() return #h end }
+end
+
 function is_writable(path)
     local file = io.open(path, "w")
     if file then
@@ -336,6 +412,42 @@ function contains_any(tab, val)
         end
     end
     return false
+end
+
+-- 将一个逗号分隔的 api_server 字符串解析为有序列表
+function get_api_server_list(api_server_str, meta)
+    local want_meta = meta or false
+    local metas = {}
+    if not api_server_str or api_server_str == "" then
+        if want_meta then return metas end
+        return {}
+    end
+
+    for part in string.gmatch(api_server_str, "[^,]+") do
+        local s = part:gsub('^%s*(.-)%s*$', '%1')
+        if s ~= '' then
+            local u, n = s:match('^(.-)[|#](.*)$')
+            local url = nil
+            local note = nil
+            if u then
+                url = u:gsub('^%s*(.-)%s*$', '%1')
+                note = n and n:gsub('^%s*(.-)%s*$', '%1') or nil
+            else
+                url = s:gsub('^%s*(.-)%s*$', '%1')
+                note = nil
+            end
+            table.insert(metas, { url = url, note = note })
+        end
+    end
+
+    if #metas == 0 and api_server_str ~= '' then
+        table.insert(metas, { url = api_server_str, note = nil })
+    end
+
+    if want_meta then return metas end
+    local urls = {}
+    for _, m in ipairs(metas) do table.insert(urls, m.url) end
+    return urls
 end
 
 --读history 和 写history
@@ -641,10 +753,29 @@ function number_to_chinese(num)
     return result
 end
 
+-- 内部的异步运行计数
+local async_running_count = 0
+
+function mark_async_start()
+    async_running_count = async_running_count + 1
+end
+
+function mark_async_end()
+    if async_running_count > 0 then
+        async_running_count = async_running_count - 1
+    end
+end
+
+function is_async_running()
+    return async_running_count > 0
+end
+
 -- 异步执行命令
 -- 同时返回 abort 函数，用于取消异步命令
 function call_cmd_async(args, callback)
-    async_running = true
+    -- 标记异步开始
+    mark_async_start()
+
     local abort_signal = mp.command_native_async({
         name = 'subprocess',
         capture_stderr = true,
@@ -652,9 +783,14 @@ function call_cmd_async(args, callback)
         playback_only = true,
         args = args,
     }, function(success, result, error)
+        -- 标记异步结束
+        mark_async_end()
+
         if not success or not result or result.status ~= 0 then
             local exit_code = (result and result.status or 'unknown')
-            local message = error or (result and result.stdout .. result.stderr) or ''
+            local message = error or (
+                result and ((result.stdout or '') .. (result.stderr or ''))
+            ) or ''
             callback('Calling failed. Exit code: ' .. exit_code .. ' Error: ' .. message, {})
             return
         end
@@ -665,5 +801,167 @@ function call_cmd_async(args, callback)
 
     return function()
         mp.abort_async_command(abort_signal)
+    end
+end
+
+local function yield_once()
+    local co = coroutine.running()
+    mp.add_timeout(0, function()
+        coroutine.resume(co)
+    end)
+    coroutine.yield()
+end
+
+local function make_safe_resume(co, timer_ref)
+    local resumed = false
+
+    return function(...)
+        if resumed then return end
+        resumed = true
+
+        if timer_ref.timer then
+            timer_ref.timer:kill()
+            timer_ref.timer = nil
+        end
+
+        local ok, err = coroutine.resume(co, ...)
+        if not ok then
+            mp.msg.warn("resume failed: " .. tostring(err))
+        end
+    end
+end
+
+function await_call_cmd(args, timeout, on_start)
+    local co = coroutine.running()
+
+    local timer_ref = { timer = nil }
+    local safe_resume = make_safe_resume(co, timer_ref)
+
+    local abort_fn = call_cmd_async(args, function(err, out)
+        safe_resume(err, out)
+    end)
+
+    if on_start and type(on_start) == 'function' then
+        pcall(on_start, abort_fn)
+    end
+
+    if timeout and type(timeout) == 'number' and timeout > 0 then
+        timer_ref.timer = mp.add_timeout(timeout, function()
+            if abort_fn then pcall(abort_fn) end
+            safe_resume("timeout", nil)
+        end)
+    end
+
+    return coroutine.yield()
+end
+
+-- 并行请求调度器
+-- servers: { "url1", "url2", ... }
+-- build_args_fn(server) -> args
+-- per_response_cb(server, err, stdout)
+-- final_cb() 可选
+-- opts: { concurrency=3, per_request_timeout=10 }
+function parallel_requests(servers, build_args_fn, per_response_cb, final_cb, opts)
+    if type(final_cb) == 'table' and opts == nil then
+        opts = final_cb
+        final_cb = nil
+    end
+
+    opts = opts or {}
+    local concurrency = opts.concurrency or 3
+    local timeout = opts.per_request_timeout or 10
+
+    local in_flight_abort = {}
+    local in_flight_count = 0
+    local aborted = false
+    local idx = 1
+    local monitor = nil
+
+    -- worker 协程
+    local function worker()
+        while true do
+            if aborted then return end
+
+            local i = idx
+            if i > #servers then return end
+            idx = idx + 1
+
+            local server = servers[i]
+            local args = build_args_fn(server)
+
+            if not args then
+                if not aborted then
+                    pcall(per_response_cb, server, "no_args", nil)
+                end
+
+                yield_once()
+            else
+                local ok, err, out = pcall(function()
+                    return await_call_cmd(args, timeout, function(ab)
+                        in_flight_abort[i] = ab
+                        in_flight_count = in_flight_count + 1
+                    end)
+                end)
+
+                -- 请求结束
+                if in_flight_abort[i] then
+                    in_flight_abort[i] = nil
+                    in_flight_count = in_flight_count - 1
+                end
+
+                if aborted then return end
+
+                if not ok then
+                    pcall(per_response_cb, server, tostring(err), nil)
+                else
+                    pcall(per_response_cb, server, err, out)
+                end
+            end
+        end
+    end
+
+    -- 启动 worker
+    local workers = {}
+    for i = 1, math.min(concurrency, #servers) do
+        local co = coroutine.create(worker)
+        local ok, res = coroutine.resume(co)
+        if not ok then
+            mp.msg.warn("worker start failed: " .. tostring(res))
+        end
+        workers[#workers + 1] = co
+    end
+
+    -- monitor（完成检测）
+    monitor = mp.add_periodic_timer(0.05, function()
+        if aborted then
+            monitor:kill()
+            return
+        end
+
+        local all_assigned = (idx > #servers)
+        local any_inflight = (in_flight_count > 0)
+
+        if all_assigned and not any_inflight then
+            monitor:kill()
+            if final_cb then pcall(final_cb) end
+        end
+    end)
+
+    -- 返回取消函数
+    return function()
+        if aborted then return end
+        aborted = true
+
+        for i, abort_fn in pairs(in_flight_abort) do
+            if abort_fn then pcall(abort_fn) end
+            in_flight_abort[i] = nil
+        end
+
+        in_flight_count = 0
+
+        if monitor then
+            monitor:kill()
+            monitor = nil
+        end
     end
 end


### PR DESCRIPTION
[Deband]
profile-desc=YUV420P10 以下的源开启去色带（排除8K视频）
profile-cond=get("video-params/average-bpp") < 24 and not (get("video-params/w") > 7000 or get("video-params/h") > 3000) profile-restore=copy
deband=yes

## 修改说明

修复 `[Deband]` 与 `[8k-fix]` 配置组冲突问题。

**问题**：8K 视频同时满足两个条件时，`[Deband]` 会覆盖 `[8k-fix]` 的 `deband=no` 设置。

**解决**：在 `[Deband]` 条件中排除 8K 分辨率。

**修改后**：
- 8K 视频：`[Deband]` 不触发 → `deband=no`
- 普通视频：`[Deband]` 正常工作 → `deband=yes`

### 问题描述

`[Deband]` 与 `[8k-fix]` 两个条件配置组存在冲突。

当同时使用以下配置时：

```lua
[Deband]
profile-desc=YUV420P10 以下的源开启去色带
profile-cond=get("video-params/average-bpp") < 24
profile-restore=copy
deband=yes

[8k-fix]
 profile-desc=8k av1 下使用 d3d11va 硬解来解决掉帧问题，该方案仅限 --gpu-api=d3d11 下可用
 profile-cond=get("video-params/w") > 7000 or get("video-params/h") > 3000
 profile-restore=copy
 hwdec=auto-safe
 video-sync=audio
 glsl-shaders=""
 deband=no
 vf=""
```

8K 视频（如 7680x4320）会同时满足两个条件：
- `average-bpp < 24` → 触发 `[Deband]`，设置 `deband=yes`
- `width > 7000` → 触发 `[8k-fix]`，设置 `deband=no`

**我尝试调换两个配置组的上下顺序，问题依旧存在。** 
实际测试中发现，这个冲突并非在所有8K视频上都出现。部分8K视频能正确激活 [8k-fix] 并关闭 deband，但另一部分8K视频（即使分辨率相同）仍会被 [Deband] 覆盖。这可能和视频的 average-bpp 具体数值或其他元数据有关，导致条件判断结果不一致。

### 解决方案

在 `[Deband]` 的条件中排除 8K 分辨率：

```lua
[Deband]
profile-desc=YUV420P10 以下的源开启去色带
profile-cond=get("video-params/average-bpp") < 24 and not (get("video-params/w") > 7000 or get("video-params/h") > 3000)
profile-restore=copy
deband=yes
```

修改后：
- 8K 视频：`[Deband]` 条件不满足（被排除），`[8k-fix]` 正常工作 → `deband=no`
- 普通视频：`[Deband]` 正常工作 → `deband=yes`

### 建议

是否可以考虑将此排除逻辑纳入默认配置，或提供更优雅的配置组优先级机制？谢谢！
希望大佬可以采纳  谢谢