### PR TITLE
Update hdr-mode.lua

### DIFF
--- a/scripts/hdr-mode.lua
+++ b/scripts/hdr-mode.lua
@@ -184,7 +184,18 @@ local function switch_hdr()
                 msg.info("Switching to HDR output...")
                 switch_display_mode(true)
             end
-            mp.add_timeout(3, continue_hdr)
+            mp.add_timeout(3, function()
+                msg.info("Seeking to 0 after HDR switch to prevent frame drop")
+                mp.set_property_number("time-pos", 0)
+                mp.commandv("vf", "toggle", "null")
+                mp.add_timeout(0.05, function()
+                    mp.commandv("vf", "toggle", "null")
+                end)
+                if not pause_changed then
+                    mp.set_property_native("pause", false)
+                end
+                continue_hdr()
+            end)
             return
         end
 


### PR DESCRIPTION
经过测试，以下修改可以完美解决 8K HDR 视频开头丢帧问题，建议合并：HDR 切换完成后 seek 到 0 并强制刷新解码器，让视频在 HDR 模式下重新解码，避免丢帧。