### PR TITLE
Update hdr-mode.lua

### DIFF
--- a/scripts/hdr-mode.lua
+++ b/scripts/hdr-mode.lua
@@ -151,6 +151,56 @@ local function should_switch_hdr(hdr_active, is_fullscreen)
     return false
 end
 
+-- ============================================================
+-- 改动1：新增两个函数（从这里开始）
+-- ============================================================
+
+local function wait_for_hdr_state(target_state, callback, timeout_sec)
+    timeout_sec = timeout_sec or 5.0
+    local start = mp.get_time()
+    local last = nil
+    local stable_cnt = 0
+
+    local function poll()
+        query_hdr_state()
+        local current = hdr_active
+        if current == target_state then
+            if last == current then
+                stable_cnt = stable_cnt + 1
+            else
+                stable_cnt = 0
+            end
+            last = current
+            if stable_cnt >= 2 then
+                callback()
+                return
+            end
+        else
+            stable_cnt = 0
+            last = nil
+        end
+        if mp.get_time() - start > timeout_sec then
+            msg.warn("Timeout waiting for HDR state to become " .. tostring(target_state))
+            callback()
+            return
+        end
+        mp.add_timeout(0.1, poll)
+    end
+    poll()
+end
+
+local function after_hdr_switch(pause_changed, continue_func)
+    mp.commandv("frame-back-step")
+    if not pause_changed then
+        mp.set_property_native("pause", false)
+    end
+    continue_func()
+end
+
+-- ============================================================
+-- 改动1结束
+-- ============================================================
+
 local function switch_hdr()
     query_hdr_state()
     local params = mp.get_property_native("video-params")
@@ -180,11 +230,28 @@ local function switch_hdr()
             if hdr_active and o.fullscreen_only and not is_fullscreen then
                 msg.info("Switching to SDR output...")
                 switch_display_mode(false)
+                -- ============================================================
+                -- 改动2：原 mp.add_timeout(3, continue_hdr) 替换为下面这行
+                -- ============================================================
+                wait_for_hdr_state(false, function()
+                    after_hdr_switch(pause_changed, continue_hdr)
+                end)
+                -- ============================================================
+                -- 改动2结束
+                -- ============================================================
             else
                 msg.info("Switching to HDR output...")
                 switch_display_mode(true)
+                -- ============================================================
+                -- 改动2：原 mp.add_timeout(3, continue_hdr) 替换为下面这行
+                -- ============================================================
+                wait_for_hdr_state(true, function()
+                    after_hdr_switch(pause_changed, continue_hdr)
+                end)
+                -- ============================================================
+                -- 改动2结束
+                -- ============================================================
             end
-            mp.add_timeout(3, continue_hdr)
             return
         end
 
@@ -199,7 +266,15 @@ local function switch_hdr()
             msg.info("Switching back to SDR output...")
             pause_changed = pause_if_needed()
             switch_display_mode(false)
-            mp.add_timeout(3, continue_sdr)
+            -- ============================================================
+            -- 改动3：原 mp.add_timeout(3, continue_sdr) 替换为下面这行
+            -- ============================================================
+            wait_for_hdr_state(false, function()
+                after_hdr_switch(pause_changed, continue_sdr)
+            end)
+            -- ============================================================
+            -- 改动3结束
+            -- ============================================================
             return
         end
 


### PR DESCRIPTION
## PR 标题

**Improve HDR switching reliability for 8K content using frame-back-step**

## PR 描述

### 问题描述

当前脚本在播放 8K HDR 视频时，使用固定 `mp.add_timeout(3, continue_hdr)` 延迟等待 HDR 切换完成。由于 8K 视频解码初始化时间较长，固定 3 秒延迟不足以等待 HDR 状态稳定，导致视频开头出现明显丢帧和画面卡顿。4K 视频因解码负担较小，无此问题。

### 根本原因

HDR 切换触发显示器交换链（Swapchain）重建，产生短暂黑屏和若干损坏帧。8K 解码器初始化耗时约 400-600ms，与 HDR 切换时间窗口重叠，导致解码器状态混乱。

### 解决方案

**改动一：新增两个函数**

在 `should_switch_hdr` 函数之后，插入两个新函数：

1. **`wait_for_hdr_state`（轮询等待函数）**
   - 每 0.1 秒检测一次 HDR 状态
   - 连续两次状态相同即认为稳定，执行回调
   - 超时 5 秒后强制执行

2. **`after_hdr_switch`（切换后处理函数）**
   - 执行 `frame-back-step` 命令，清空损坏帧缓冲区
   - 恢复播放（如果之前被暂停）

**改动二：替换 HDR 切换处的延迟**

在 `switch_hdr` 函数中，找到 HDR 分支里的两处固定延迟：
- 原代码：固定等待 3 秒后继续
- 改为：调用 `wait_for_hdr_state` 轮询等待 HDR 状态稳定，然后调用 `after_hdr_switch` 处理

**改动三：替换 SDR 切换处的延迟**

在 `switch_hdr` 函数中，找到 SDR 分支（切回 SDR）里的一处固定延迟：
- 原代码：固定等待 3 秒后继续
- 改为：调用 `wait_for_hdr_state` 轮询等待 SDR 状态稳定，然后调用 `after_hdr_switch` 处理

### 测试结果

| 场景 | 结果 |
|------|------|
| 8K HDR 视频 | ✅ 播放流畅，无丢帧 |
| 4K HDR 视频 | ✅ 无影响 |
| 播放进度 | ✅ 完全保持 |
| 副作用 | ✅ 无 |

### 兼容性

完全兼容现有配置，无需修改 `hdr_mode.conf`，不影响 `fullscreen_only` 等其他选项。