### PR TITLE
display-info.dll：mpv 退出后显示器 HDR 模式偶发未关闭（script-message 与插件卸载存在竞态条件）  

### DIFF
--- a/scripts/hdr-mode.lua
+++ b/scripts/hdr-mode.lua
@@ -313,6 +313,7 @@ local function on_end(event)
         if hdr_active then
             msg.info("Restoring display to SDR on shutdown")
             switch_display_mode(false)
+            utils.sleep(0.5)
         end
     end
 end


### PR DESCRIPTION
close：https://github.com/dyphire/mpv-config/issues/332

### 问题
mpv 退出时 HDR 偶发无法关闭，原因是 `script-message` 是异步的，`display-info.dll` 还没处理完命令就被销毁了。

### 修复
在 `on_end` 的 `quit` 分支中，发送关闭命令后等待 500ms，确保 display-info 有足够时间完成 HDR 切换。

### 测试
本地已测试，退出时 HDR 正常关闭，无副作用。
