### PR TITLE
fix: fps-fix profile 条件使用 >= 修复 120Hz 边界不触发的问题

### DIFF
--- a/mpv.conf
+++ b/mpv.conf
@@ -944,7 +944,7 @@ profile=NNEDI3                                # 适用于大多数场景（NNEDI
 
 [fps-fix]
  profile-desc=修复视频帧率和显示刷新率过高引起的异常耗能或掉帧
- profile-cond=get("estimated-vf-fps") > 47 or get("display-fps") > 120
+ profile-cond=get("estimated-vf-fps") >= 47 or get("display-fps") >= 120
  profile-restore=copy
  video-sync=audio
 


### PR DESCRIPTION
实际影响
以 15fps 视频 + 120Hz 显示器为例：

fps-fix 不触发，配置停留在 video-sync=display-resample + interpolation 模式
视频帧率与显示器刷新率比值为 8:1，libplacebo 的显示器 FPS 估算出现严重异常，估算值在 120~1200Hz 之间剧烈波动
将 > 改为 >=，使边界值（120Hz、47fps）能正确触发 profile：