### PR TITLE
refactor: fps-fix 使用帧率比值判断替代绝对值判断

### DIFF
--- a/mpv.conf
+++ b/mpv.conf
@@ -944,8 +944,9 @@ profile=NNEDI3                                # 适用于大多数场景（NNEDI
 
 [fps-fix]
  profile-desc=修复视频帧率和显示刷新率过高引起的异常耗能或掉帧
- profile-cond=get("estimated-vf-fps") > 47 or get("display-fps") > 120
+ profile-cond=p.container_fps>32 or (p.display_fps/p.container_fps)>3.2 
  profile-restore=copy
+ interpolation=no
  video-sync=audio
 
 [8k-fix]


### PR DESCRIPTION
前 fps-fix 使用 get("display-fps") >= 120 绝对值判断，存在两个局限：

无法覆盖非 120Hz 显示器：90Hz、144Hz 等刷新率与低帧率视频（如 15fps）组合同样会出现 display-resample 的 FPS 估算异常，但因不满足 >= 120 条件而不触发
缺少 interpolation = no：切换到 video-sync=audio 后 interpolation 本不应生效，但显式关闭可避免 profile restore 时序残留
改用 display_fps / container_fps > 3.2 比值判断，适配任意显示器刷新率，当帧率比值过大时自动切换到 audio 同步模式，避免 display-resample 在高比值下的 FPS 估算崩溃。

参考实现：hooke007/mpv-lazy 的 vsync_auto

与 [#336](https://github.com/dyphire/mpv-config/pull/336) 互斥，二选一即可